### PR TITLE
Reduce number of AWS subnets down to 4

### DIFF
--- a/qhub/template/{{ cookiecutter.repo_directory }}/infrastructure/modules/aws/network/variables.tf
+++ b/qhub/template/{{ cookiecutter.repo_directory }}/infrastructure/modules/aws/network/variables.tf
@@ -40,5 +40,5 @@ variable "vpc_cidr_block" {
 variable "vpc_cidr_newbits" {
   description = "VPC cidr number of bits to support 2^N subnets"
   type        = number
-  default     = 4
+  default     = 2
 }


### PR DESCRIPTION
Based on our discussion in #828. This is not the long term solution but will enable 4x nodes on QHub deployed on AWS.

Closes #828 