### PR TITLE
[Docs] Add reference for conda-store image

### DIFF
--- a/docs/source/admin_guide/system_maintenance.md
+++ b/docs/source/admin_guide/system_maintenance.md
@@ -15,6 +15,7 @@ are three images that are currently built
 - jupyterlab :: modification of jupyterlab instances for each user
 - dask-worker :: modification of dask workers and dask scheduler
 - jupyterhub :: the jupyterhub server (allows for customization of hub UI)
+- conda-store :: Environment management tool for QHub
 
 Each docker image is customized with its respective directory
 (e.g. `image/Dockerfile.jupyterlab` -> `image/jupyterlab/*`. For

--- a/docs/source/admin_guide/upgrade.md
+++ b/docs/source/admin_guide/upgrade.md
@@ -29,6 +29,7 @@ default_images:
   jupyterlab: quansight/qhub-jupyterlab:v<version>
   dask_worker: quansight/qhub-dask-worker:v<version>
   dask_gateway: quansight/qhub-dask-gateway:v<version>
+  conda_store: quansight/qhub-conda-store:v<version>
 ...
 profiles:
   jupyterlab:

--- a/docs/source/installation/configuration.md
+++ b/docs/source/installation/configuration.md
@@ -509,6 +509,7 @@ default_images:
   jupyterlab: "quansight/qhub-jupyterlab:v||QHUB_VERSION||"
   dask_worker: "quansight/qhub-dask-worker:v||QHUB_VERSION||"
   dask_gateway: "quansight/qhub-dask-gateway:v||QHUB_VERSION||"
+  conda_store: "quansight/qhub-conda-store:v||QHUB_VERSION||"
 ```
 
 ## Storage
@@ -592,7 +593,7 @@ important considerations to make. Two important terms to understand are:
    than the node specification. See this [guide from digital
    ocean](https://docs.digitalocean.com/products/kubernetes/#allocatable-memory)
    which is generally applicable to other clouds.
-   
+
 For example if a node is 8 GB of ram and 2 cpu you should
 guarantee/schedule roughly 75% and follow the digital ocean guide
 linked above. E.g. 1.5 cpu guarantee and 5.5 GB guaranteed.
@@ -734,7 +735,7 @@ project_name: do-jupyterhub
 provider: do
 domain: "do.qhub.dev"
 
-ci_cd: 
+ci_cd:
   type: github-actions
   branch: main
 
@@ -797,6 +798,7 @@ default_images:
   jupyterhub: "quansight/qhub-jupyterhub:v||QHUB_VERSION||"
   jupyterlab: "quansight/qhub-jupyterlab:v||QHUB_VERSION||"
   dask_worker: "quansight/qhub-dask-worker:v||QHUB_VERSION||"
+  conda_store: "quansight/qhub-conda-store:v||QHUB_VERSION||"
 
 theme:
   jupyterhub:


### PR DESCRIPTION
Reference about conda-store docker image as a QHub [default-image](https://docs.qhub.dev/en/stable/source/04_how_to_guides/2_qhub-gcp-deploy_guide.html?highlight=default#default-images), in the `qhub-config` file, was missing in the https://github.com/Quansight/qhub/pull/623