### PR TITLE
escape dollar in docs, sphinx considers it as math

### DIFF
--- a/docs/source/admin_guide/cost.md
+++ b/docs/source/admin_guide/cost.md
@@ -2,8 +2,8 @@
 
 Qhub does not charge a fee for infrastructure but cloud providers
 themselves have pricing for all their services. A digital ocean
-cluster's minimum fixed cost is around $60/month. While other cloud
-providers fixed cost is around $200/month. Each cloud vendor has
+cluster's minimum fixed cost is around \$60/month. While other cloud
+providers fixed cost is around \$200/month. Each cloud vendor has
 different pricing and capabilities of their kubernetes offerings which
 can significantly affect the pricing of QHub. Cost alone does not
 determine which cloud is best for your use case. Often times you
@@ -67,7 +67,7 @@ type of storage has well known advantages and limitations.
 | Cloud                 | Object   | Block         | Filesystem                       |
 |:----------------------|:---------|:--------------|----------------------------------|
 | Digital Ocean         | $0.02/GB | $0.10/GB      | N/A                              |
-| Google Cloud Platform | $0.02/GB | $0.4-0.12/GB  | $0.20-0.30/GB (1TB minimum $200) |
+| Google Cloud Platform | $0.02/GB | $0.4-0.12/GB  | \$0.20-0.30/GB (1TB minimum \$200) |
 | Amazon Web Services   | $0.02/GB | $0.05-0.12/GB | $0.30/GB                         |
 | Azure                 | $0.02/GB | $0.6-0.12/GB  | $0.16/GB                         |
 


### PR DESCRIPTION
## Description

I have noticed a weird italic and bigger font in the docs, on page [Administration Guide / Cloud Cost and Capabilities](https://docs.qhub.dev/en/latest/source/admin_guide/cost.html) : 

![Capture d’écran 2021-10-14 à 18 29 51](https://user-images.githubusercontent.com/756464/137359071-cb8b6b22-14c7-42c0-8bc6-234b23e80829.png)
![Capture d’écran 2021-10-14 à 18 29 57](https://user-images.githubusercontent.com/756464/137359078-cc6ee5d2-ceed-4dc5-a3f5-2fa07f9e7822.png)


## Diagnostic 

The dollar signs are interpreted by sphinx as math expressions. Any line containing two dollars will have the in-between text represented as such. You need an opening and a closing one, that's why it doesn't appear for every occurrences of the dollar sign in the page.

## Fix 

I simply escaped the dollar signs. 
