### PR TITLE
Upgrade default `general` node instance types

### DIFF
--- a/qhub/initialize.py
+++ b/qhub/initialize.py
@@ -138,7 +138,7 @@ AZURE = {
     "kubernetes_version": "1.18.19",
     "node_groups": {
         "general": {
-            "instance": "Standard_D2_v2",
+            "instance": "Standard_D4_v3",
             "min_nodes": 1,
             "max_nodes": 1,
         },


### PR DESCRIPTION
For AWS: `m5.xlarge` 
- 4 vCPU
- 16 GB RAM

For Azure: `Standard_D4_v3`
- 4 vCPU
- 16 GB RAM

For GCP: `n1-standard-4`
- 4 vCPU
- 15 GB RAM

DO default `general` instance types remain the same: `g-4vcpu-16gb` (4 vCPU and 16 GB RAM).

Changes also include strict pins for the `dashboard` conda environment to reduce build time considerably. Thanks @tylerpotts for his assistance here.

This PR is a part of the 0.3.13 release PR #852.