### PR TITLE
replace deprecated "minikube cache add" with "minikube image load"

### DIFF
--- a/docs/source/dev_guide/minikube.md
+++ b/docs/source/dev_guide/minikube.md
@@ -127,11 +127,11 @@ Replacing `v0.x.x` with the current version that is listed. Note this may take s
 After the images are pulled, they can be copied to the Minikube cache like so:
 
 ```bash
-minikube cache add quansight/qhub-jupyterhub:v0.x.x
-minikube cache add quansight/qhub-jupyterlab:v0.x.x
-minikube cache add quansight/qhub-dask-worker:v0.x.x
-minikube cache add quansight/qhub-dask-gateway:v0.x.x
-minikube cache add quansight/qhub-conda-store:v0.x.x
+minikube image load quansight/qhub-jupyterhub:v0.x.x
+minikube image load quansight/qhub-jupyterlab:v0.x.x
+minikube image load quansight/qhub-dask-worker:v0.x.x
+minikube image load quansight/qhub-dask-gateway:v0.x.x
+minikube image load quansight/qhub-conda-store:v0.x.x
 ```
 
 Again, adding the correct version. With this completed local Minikube deployment will no longer require pulling the above docker images.


### PR DESCRIPTION
I'm seeing the following currently:
`! "minikube cache" will be deprecated in upcoming versions, please switch to "minikube image load"`

when running the `minikube cache add` under the minikube testing docs.  

This PR updates the minikube command.