### PR TITLE
CI: Spinup unique cirun runners for each job

### DIFF
--- a/.cirun.yml
+++ b/.cirun.yml
@@ -1,5 +1,5 @@
 # Self-Hosted Github Action Runners on AWS via Cirun.io
-# Reference: https://docs.cirun.io/reference/yaml.html
+# Reference: https://docs.cirun.io/reference/yaml
 runners:
   - name: run-k8s-tests
     # Cloud Provider: AWS

--- a/.github/workflows/kubernetes_test.yaml
+++ b/.github/workflows/kubernetes_test.yaml
@@ -28,7 +28,7 @@ on:
 jobs:
   test-kubernetes:
     name: "Kubernetes Tests"
-    runs-on: [self-hosted, cirun-runner]
+    runs-on: "cirun-runner--${{ github.run_id }}"
     defaults:
       run:
         shell: bash -l {0}


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://nebari.dev/community
-->

Sometimes it happens, when a runner is created for a job, it gets consumed by a job queued earlier, causing confusion sometimes. This PR makes sure, the runner is only consumed by the job it was created by. It's cirun's new feature, read more here: https://docs.cirun.io/reference/unique-runner-labels

## Reference Issues or PRs

<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create a link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

## What does this implement/fix?

_Put a `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds a feature)
- [ ] Breaking change (fix or feature that would cause existing features not to work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [x] Build related changes
- [ ] Other (please describe):

## Testing

- [ ] Did you test the pull request locally?
- [ ] Did you add new tests?

## Any other comments?

<!--
Please be aware that we are a loose team of volunteers, so patience is necessary;
assistance handling other issues is very welcome.
We value all user contributions. If we are slow to review, either the pull request needs some benchmarking, tinkering,
convincing, etc., or the reviewers are likely busy. In either case,
we ask for your understanding during the
review process.
Thanks for contributing to Nebari 🙏🏼!
-->
