### PR TITLE
Adding jupyterlab-conda-store extension support to Nebari

### DIFF
--- a/nebari/template/stages/07-kubernetes-services/conda-store.tf
+++ b/nebari/template/stages/07-kubernetes-services/conda-store.tf
@@ -36,7 +36,7 @@ variable "conda-store-image" {
 variable "conda-store-image-tag" {
   description = "Version of conda-store to use"
   type        = string
-  default     = "v0.4.9"
+  default     = "v0.4.12"
 }
 
 # ====================== RESOURCES =======================

--- a/nebari/template/stages/07-kubernetes-services/modules/kubernetes/services/jupyterhub/files/jupyterlab/overrides.json
+++ b/nebari/template/stages/07-kubernetes-services/modules/kubernetes/services/jupyterhub/files/jupyterlab/overrides.json
@@ -1,5 +1,11 @@
 {
     "dask-labextension:plugin": {
         "browserDashboardCheck": true
+    },
+    "jupyterlab-conda-store:plugin": {
+        "apiUrl": "/conda-store/",
+        "authMethod": "cookie",
+        "loginUrl": "/conda-store/login?next=",
+        "authToken": ""
     }
 }


### PR DESCRIPTION
This PR depends on
https://github.com/nebari-dev/nebari-docker-images/pull/41 being merged.

Additionally fixes an unupdated section where we specified an older conda-store version.

We override the conda-store url in the jupyterlab settings overrides.

## Reference Issues or PRs
 - https://github.com/nebari-dev/nebari-docker-images/pull/41

## What does this implement/fix?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds a feature)
- [ ] Breaking change (fix or feature that would cause existing features not to work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Other (please describe):
