### PR TITLE
Set GKE release_channel to unspecified to prevent auto k8s updates

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -63,7 +63,7 @@ repos:
         args: ["--fix"]
 
   - repo: https://github.com/pycqa/isort
-    rev: 5.11.4
+    rev: 5.12.0
     hooks:
       - id: isort
         name: isort

--- a/nebari/template/stages/02-infrastructure/gcp/modules/kubernetes/main.tf
+++ b/nebari/template/stages/02-infrastructure/gcp/modules/kubernetes/main.tf
@@ -20,6 +20,10 @@ resource "google_container_cluster" "main" {
     }
   }
 
+  release_channel {
+    channel = "UNSPECIFIED"
+  }
+
   networking_mode = var.networking_mode
   network         = var.network
   subnetwork      = var.subnetwork


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://nebari.dev/community
-->

## Reference Issues or PRs

<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create a link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

## What does this implement/fix?

_Put a `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds a feature)
- [ ] Breaking change (fix or feature that would cause existing features not to work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [x] Build related changes
- [ ] Other (please describe):

## Testing

- [x] Did you test the pull request locally?
- [ ] Did you add new tests?

I created a new Nebari cluster to test that this would work as expected. I also upgraded an existing cluster to validate that it would work for those clusters as well. No issues detected. Node pools may be destroyed and recreated if there are version differences. More information about `release_channel` can be found [here](https://cloud.google.com/kubernetes-engine/docs/concepts/release-channels) and [here](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/container_cluster#release_channel).

## Any other comments?

<!--
Please be aware that we are a loose team of volunteers, so patience is necessary;
assistance handling other issues is very welcome.
We value all user contributions. If we are slow to review, either the pull request needs some benchmarking, tinkering,
convincing, etc., or the reviewers are likely busy. In either case,
we ask for your understanding during the
review process.
Thanks for contributing to Nebari 🙏🏼!
-->
