### PR TITLE
Feature remove jupyterlab news

### DIFF
--- a/nebari/template/stages/07-kubernetes-services/modules/kubernetes/services/jupyterhub/files/jupyterlab/overrides.json
+++ b/nebari/template/stages/07-kubernetes-services/modules/kubernetes/services/jupyterhub/files/jupyterlab/overrides.json
@@ -7,5 +7,8 @@
         "authMethod": "cookie",
         "loginUrl": "/conda-store/login?next=",
         "authToken": ""
+    },
+    "@jupyterlab/apputils-extension:notification": {
+        "fetchNews": "false"
     }
 }


### PR DESCRIPTION
Remove the following popup

<img width="405" alt="image" src="https://user-images.githubusercontent.com/1740337/216679655-2c4c84f8-f0a5-4b7e-a4c5-05c643392b84.png">


```shell
jupyter labextension disable "@jupyterlab/apputils-extension:announcements"
```

and

```json
{
    "@jupyterlab/apputils-extension:notification": {
        "fetchNews": "false"
    }
}
```
