### PR TITLE
PR lower dashboard launch timeout

### DIFF
--- a/nebari/template/stages/07-kubernetes-services/modules/kubernetes/services/jupyterhub/files/jupyterhub/02-spawner.py
+++ b/nebari/template/stages/07-kubernetes-services/modules/kubernetes/services/jupyterhub/files/jupyterhub/02-spawner.py
@@ -78,8 +78,8 @@ if cdsdashboards["enabled"]:
     )
 
     # TODO: make timeouts configurable
-    c.VariableMixin.proxy_ready_timeout = 600
-    c.VariableMixin.proxy_request_timeout = 600
+    c.VariableMixin.proxy_ready_timeout = 300
+    c.VariableMixin.proxy_request_timeout = 300
 
     home_username = f"/home/{os.getenv('PREFERRED_USERNAME')}"
     c.CDSDashboardsConfig.extra_presentation_types = ["panel-serve"]


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://nebari.dev/community
-->
This PR will reduce the time it takes for a dashboard launch to timeout.  It is now set to 5 minutes. There was some discussion about making this configurable, but I thought that could go in another PR, and at least lower it for now.  


## Reference Issues or PRs

<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create a link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

## What does this implement/fix?
Fixes #1616 
_Put a `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds a feature)
- [ ] Breaking change (fix or feature that would cause existing features not to work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Other (please describe):

## Testing

- [ ] Did you test the pull request locally?
- [ ] Did you add new tests?

## Any other comments?

<!--
Please be aware that we are a loose team of volunteers, so patience is necessary;
assistance handling other issues is very welcome.
We value all user contributions. If we are slow to review, either the pull request needs some benchmarking, tinkering,
convincing, etc., or the reviewers are likely busy. In either case,
we ask for your understanding during the
review process.
Thanks for contributing to Nebari 🙏🏼!
-->
