### PR TITLE
Github Actions CI needs id-token write permissions

### DIFF
--- a/nebari/provider/cicd/github.py
+++ b/nebari/provider/cicd/github.py
@@ -171,6 +171,7 @@ class GHA_job_step(BaseModel):
 class GHA_job_id(BaseModel):
     name: str
     runs_on_: str = Field(alias="runs-on")
+    permissions: Optional[Dict[str, str]]
     steps: List[GHA_job_step]
 
     class Config:
@@ -272,7 +273,15 @@ def gen_nebari_ops(config):
     for step in config["ci_cd"].get("after_script", []):
         gha_steps.append(GHA_job_step(**step))
 
-    job1 = GHA_job_id(name="nebari", runs_on_="ubuntu-latest", steps=gha_steps)
+    job1 = GHA_job_id(
+        name="nebari",
+        runs_on_="ubuntu-latest",
+        permissions={
+            "id-token": "write",
+            "contents": "read",
+        },
+        steps=gha_steps
+    )
     jobs = GHA_jobs(__root__={"build": job1})
 
     return NebariOps(

--- a/nebari/provider/cicd/github.py
+++ b/nebari/provider/cicd/github.py
@@ -280,7 +280,7 @@ def gen_nebari_ops(config):
             "id-token": "write",
             "contents": "read",
         },
-        steps=gha_steps
+        steps=gha_steps,
     )
     jobs = GHA_jobs(__root__={"build": job1})
 


### PR DESCRIPTION
Related to the need for OIDC support when deploying nebari see issue 
## Reference Issues or PRs

## What does this implement/fix?

https://github.com/nebari-dev/nebari/issues/1671

_Put a `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds a feature)
- [ ] Breaking change (fix or feature that would cause existing features not to work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Other (please describe):

## Testing

- [X] Did you test the pull request locally?
- [ ] Did you add new tests?

## Any other comments?

This adds the following lines to the render for github

```yaml
    permissions:
      id-token: write
      contents: read
```

To the github actions pipeline. From a security perspective there are no risks I can see of adding id-token to the pipeline.