### PR TITLE
Make idle culler settings configurable from the `nebari-config.yaml`

### DIFF
--- a/nebari/schema.py
+++ b/nebari/schema.py
@@ -352,6 +352,23 @@ class JupyterHub(Base):
     overrides: typing.Optional[typing.Dict]
 
 
+# ================= JupyterLab ==================
+
+
+class IdleCuller(Base):
+    terminal_cull_inactive_timeout = typing.Optional[int]
+    terminal_cull_interval = typing.Optional[int]
+    kernel_cull_idle_timeout = typing.Optional[int]
+    kernel_cull_interval = typing.Optional[int]
+    kernel_cull_connected = typing.Optional[bool]
+    kernel_cull_busy = typing.Optional[bool]
+    server_shutdown_no_activity_timeout = typing.Optional[int]
+
+
+class JupyterLab(Base):
+    idle_culler: typing.Optional[IdleCuller]
+
+
 # ================== Profiles ==================
 
 
@@ -585,6 +602,7 @@ class Main(Base):
     clearml: typing.Optional[ClearML]
     tf_extensions: typing.Optional[typing.List[NebariExtension]]
     jupyterhub: typing.Optional[JupyterHub]
+    jupyterlab: typing.Optional[JupyterLab]
     prevent_deploy: bool = (
         False  # Optional, but will be given default value if not present
     )

--- a/nebari/schema.py
+++ b/nebari/schema.py
@@ -356,13 +356,13 @@ class JupyterHub(Base):
 
 
 class IdleCuller(Base):
-    terminal_cull_inactive_timeout = typing.Optional[int]
-    terminal_cull_interval = typing.Optional[int]
-    kernel_cull_idle_timeout = typing.Optional[int]
-    kernel_cull_interval = typing.Optional[int]
-    kernel_cull_connected = typing.Optional[bool]
-    kernel_cull_busy = typing.Optional[bool]
-    server_shutdown_no_activity_timeout = typing.Optional[int]
+    terminal_cull_inactive_timeout: typing.Optional[int]
+    terminal_cull_interval: typing.Optional[int]
+    kernel_cull_idle_timeout: typing.Optional[int]
+    kernel_cull_interval: typing.Optional[int]
+    kernel_cull_connected: typing.Optional[bool]
+    kernel_cull_busy: typing.Optional[int]
+    server_shutdown_no_activity_timeout: typing.Optional[int]
 
 
 class JupyterLab(Base):

--- a/nebari/stages/input_vars.py
+++ b/nebari/stages/input_vars.py
@@ -322,7 +322,7 @@ def stage_07_kubernetes_services(stage_outputs, config):
             .get("extraEnv", [])
         ),
         # jupyterlab
-        "jupyterlab": config.get("jupyterlab", {}),
+        "idle-culler-settings": config.get("jupyterlab", {}).get("idle_culler", {}),
         # dask-gateway
         "dask-worker-image": _split_docker_image_name(
             config["default_images"]["dask_worker"]

--- a/nebari/stages/input_vars.py
+++ b/nebari/stages/input_vars.py
@@ -321,6 +321,8 @@ def stage_07_kubernetes_services(stage_outputs, config):
             .get("hub", {})
             .get("extraEnv", [])
         ),
+        # jupyterlab
+        "jupyterlab": config.get("jupyterlab", {}),
         # dask-gateway
         "dask-worker-image": _split_docker_image_name(
             config["default_images"]["dask_worker"]

--- a/nebari/template/stages/07-kubernetes-services/jupyterhub.tf
+++ b/nebari/template/stages/07-kubernetes-services/jupyterhub.tf
@@ -133,4 +133,7 @@ module "jupyterhub" {
 
   jupyterhub-logout-redirect-url = var.jupyterhub-logout-redirect-url
   jupyterhub-hub-extraEnv        = var.jupyterhub-hub-extraEnv
+
+  idle-culler-settings = local.idle-culler-settings
+
 }

--- a/nebari/template/stages/07-kubernetes-services/modules/kubernetes/services/jupyterhub/configmaps.tf
+++ b/nebari/template/stages/07-kubernetes-services/modules/kubernetes/services/jupyterhub/configmaps.tf
@@ -1,19 +1,19 @@
 locals {
-  jupyter_notebook_config_py_template = templatefile("${path.module}/files/jupyter/jupyter_notebook_config.py.tpl", {
-    terminal_cull_inactive_timeout      = var.terminal_cull_inactive_timeout
-    terminal_cull_interval              = var.terminal_cull_interval
-    kernel_cull_idle_timeout            = var.kernel_cull_idle_timeout
-    kernel_cull_interval                = var.kernel_cull_interval
-    kernel_cull_connected               = var.kernel_cull_connected ? "True" : "False" # for Python compatible boolean values
-    kernel_cull_busy                    = var.kernel_cull_busy ? "True" : "False"      # for Python compatible boolean values
-    server_shutdown_no_activity_timeout = var.server_shutdown_no_activity_timeout
+  jupyter-notebook-config-py-template = templatefile("${path.module}/files/jupyter/jupyter_notebook_config.py.tpl", {
+    terminal_cull_inactive_timeout      = var.idle-culler-settings.terminal_cull_inactive_timeout
+    terminal_cull_interval              = var.idle-culler-settings.terminal_cull_interval
+    kernel_cull_idle_timeout            = var.idle-culler-settings.kernel_cull_idle_timeout
+    kernel_cull_interval                = var.idle-culler-settings.kernel_cull_interval
+    kernel_cull_connected               = var.idle-culler-settings.kernel_cull_connected ? "True" : "False" # for Python compatible boolean values
+    kernel_cull_busy                    = var.idle-culler-settings.kernel_cull_busy ? "True" : "False"      # for Python compatible boolean values
+    server_shutdown_no_activity_timeout = var.idle-culler-settings.server_shutdown_no_activity_timeout
     }
   )
 }
 
 
 resource "local_file" "jupyter_notebook_config_py" {
-  content  = local.jupyter_notebook_config_py_template
+  content  = local.jupyter-notebook-config-py-template
   filename = "${path.module}/files/jupyter/jupyter_notebook_config.py"
 }
 

--- a/nebari/template/stages/07-kubernetes-services/modules/kubernetes/services/jupyterhub/configmaps.tf
+++ b/nebari/template/stages/07-kubernetes-services/modules/kubernetes/services/jupyterhub/configmaps.tf
@@ -1,3 +1,23 @@
+locals {
+  jupyter_notebook_config_py_template = templatefile("${path.module}/files/jupyter/jupyter_notebook_config.py.tpl", {
+    terminal_cull_inactive_timeout      = var.terminal_cull_inactive_timeout
+    terminal_cull_interval              = var.terminal_cull_interval
+    kernel_cull_idle_timeout            = var.kernel_cull_idle_timeout
+    kernel_cull_interval                = var.kernel_cull_interval
+    kernel_cull_connected               = var.kernel_cull_connected ? "True" : "False" # for Python compatible boolean values
+    kernel_cull_busy                    = var.kernel_cull_busy ? "True" : "False"      # for Python compatible boolean values
+    server_shutdown_no_activity_timeout = var.server_shutdown_no_activity_timeout
+    }
+  )
+}
+
+
+resource "local_file" "jupyter_notebook_config_py" {
+  content  = local.jupyter_notebook_config_py_template
+  filename = "${path.module}/files/jupyter/jupyter_notebook_config.py"
+}
+
+
 resource "kubernetes_config_map" "etc-ipython" {
   metadata {
     name      = "etc-ipython"
@@ -12,14 +32,17 @@ resource "kubernetes_config_map" "etc-ipython" {
 
 
 resource "kubernetes_config_map" "etc-jupyter" {
+  depends_on = [
+    local_file.jupyter_notebook_config_py
+  ]
+
   metadata {
     name      = "etc-jupyter"
     namespace = var.namespace
   }
 
   data = {
-    for filename in fileset("${path.module}/files/jupyter", "*") :
-    filename => file("${path.module}/files/jupyter/${filename}")
+    "jupyter_notebook_config.py" : local_file.jupyter_notebook_config_py.content
   }
 }
 

--- a/nebari/template/stages/07-kubernetes-services/modules/kubernetes/services/jupyterhub/files/jupyter/jupyter_notebook_config.py.tpl
+++ b/nebari/template/stages/07-kubernetes-services/modules/kubernetes/services/jupyterhub/files/jupyter/jupyter_notebook_config.py.tpl
@@ -7,31 +7,31 @@
 
 # Timeout (in seconds) in which a terminal has been inactive and ready to
 # be culled.
-c.TerminalManager.cull_inactive_timeout = '${terminal_cull_inactive_timeout}' * 60
+c.TerminalManager.cull_inactive_timeout = ${terminal_cull_inactive_timeout} * 60
 
 # The interval (in seconds) on which to check for terminals exceeding the
 # inactive timeout value.
-c.TerminalManager.cull_interval = '${terminal_cull_interval}' * 60
+c.TerminalManager.cull_interval = ${terminal_cull_interval} * 60
 
 # cull_idle_timeout: timeout (in seconds) after which an idle kernel is
 # considered ready to be culled
-c.MappingKernelManager.cull_idle_timeout = '${kernel_cull_idle_timeout}' * 60
+c.MappingKernelManager.cull_idle_timeout = ${kernel_cull_idle_timeout} * 60
 
 # cull_interval: the interval (in seconds) on which to check for idle
 # kernels exceeding the cull timeout value
-c.MappingKernelManager.cull_interval = '${kernel_cull_interval}' * 60
+c.MappingKernelManager.cull_interval = ${kernel_cull_interval} * 60
 
 # cull_connected: whether to consider culling kernels which have one
 # or more connections
-c.MappingKernelManager.cull_connected = '${kernel_cull_connected}'
+c.MappingKernelManager.cull_connected = ${kernel_cull_connected}
 
 # cull_busy: whether to consider culling kernels which are currently
 # busy running some code
-c.MappingKernelManager.cull_busy = '${kernel_cull_busy}'
+c.MappingKernelManager.cull_busy = ${kernel_cull_busy}
 
 # Shut down the server after N seconds with no kernels or terminals
 # running and no activity.
-c.NotebookApp.shutdown_no_activity_timeout = '${server_shutdown_no_activity_timeout}' * 60
+c.NotebookApp.shutdown_no_activity_timeout = ${server_shutdown_no_activity_timeout} * 60
 
 ###############################################################################
 # JupyterHub idle culler total timeout corresponds (approximately) to:

--- a/nebari/template/stages/07-kubernetes-services/modules/kubernetes/services/jupyterhub/files/jupyter/jupyter_notebook_config.py.tpl
+++ b/nebari/template/stages/07-kubernetes-services/modules/kubernetes/services/jupyterhub/files/jupyter/jupyter_notebook_config.py.tpl
@@ -7,31 +7,31 @@
 
 # Timeout (in seconds) in which a terminal has been inactive and ready to
 # be culled.
-c.TerminalManager.cull_inactive_timeout = 30 * 60
+c.TerminalManager.cull_inactive_timeout = '${terminal_cull_inactive_timeout}' * 60
 
 # The interval (in seconds) on which to check for terminals exceeding the
 # inactive timeout value.
-c.TerminalManager.cull_interval = 5 * 60
+c.TerminalManager.cull_interval = '${terminal_cull_interval}' * 60
 
 # cull_idle_timeout: timeout (in seconds) after which an idle kernel is
 # considered ready to be culled
-c.MappingKernelManager.cull_idle_timeout = 30 * 60
+c.MappingKernelManager.cull_idle_timeout = '${kernel_cull_idle_timeout}' * 60
 
 # cull_interval: the interval (in seconds) on which to check for idle
 # kernels exceeding the cull timeout value
-c.MappingKernelManager.cull_interval = 5 * 60
+c.MappingKernelManager.cull_interval = '${kernel_cull_interval}' * 60
 
 # cull_connected: whether to consider culling kernels which have one
 # or more connections
-c.MappingKernelManager.cull_connected = True
+c.MappingKernelManager.cull_connected = '${kernel_cull_connected}'
 
 # cull_busy: whether to consider culling kernels which are currently
 # busy running some code
-c.MappingKernelManager.cull_busy = False
+c.MappingKernelManager.cull_busy = '${kernel_cull_busy}'
 
 # Shut down the server after N seconds with no kernels or terminals
 # running and no activity.
-c.NotebookApp.shutdown_no_activity_timeout = 30 * 60
+c.NotebookApp.shutdown_no_activity_timeout = '${server_shutdown_no_activity_timeout}' * 60
 
 ###############################################################################
 # JupyterHub idle culler total timeout corresponds (approximately) to:

--- a/nebari/template/stages/07-kubernetes-services/modules/kubernetes/services/jupyterhub/variables.tf
+++ b/nebari/template/stages/07-kubernetes-services/modules/kubernetes/services/jupyterhub/variables.tf
@@ -145,44 +145,15 @@ variable "default-conda-store-namespace" {
   type        = string
 }
 
-variable "terminal_cull_inactive_timeout" {
-  description = "Timeout (in minutess) in which a terminal has been inactive and ready to be culled"
-  type        = number
-  default     = 30
-}
-
-variable "terminal_cull_interval" {
-  description = "The interval (in minutes) on which to check for terminals exceeding the inactive timeout value"
-  type        = number
-  default     = 5
-}
-
-variable "kernel_cull_idle_timeout" {
-  description = "Timeout (in minutes) after which an idle kernel is considered ready to be culled"
-  type        = number
-  default     = 30
-}
-
-variable "kernel_cull_interval" {
-  description = "The interval (in minutes) on which to check for idle kernels exceeding the cull timeout value"
-  type        = number
-  default     = 5
-}
-
-variable "kernel_cull_connected" {
-  description = "Whether to consider culling kernels which have one or more connections"
-  type        = bool
-  default     = true
-}
-
-variable "kernel_cull_busy" {
-  description = "Whether to consider culling kernels which are currently busy running some code"
-  type        = bool
-  default     = false
-}
-
-variable "server_shutdown_no_activity_timeout" {
-  description = "Shut down the server after N minutes with no kernels or terminals running and no activity"
-  type        = number
-  default     = 15
+variable "idle-culler-settings" {
+  description = "Idle culler timeout settings (in minutes)"
+  type = object({
+    kernel_cull_busy                    = bool
+    kernel_cull_connected               = bool
+    kernel_cull_idle_timeout            = number
+    kernel_cull_interval                = number
+    server_shutdown_no_activity_timeout = number
+    terminal_cull_inactive_timeout      = number
+    terminal_cull_interval              = number
+  })
 }

--- a/nebari/template/stages/07-kubernetes-services/modules/kubernetes/services/jupyterhub/variables.tf
+++ b/nebari/template/stages/07-kubernetes-services/modules/kubernetes/services/jupyterhub/variables.tf
@@ -144,3 +144,45 @@ variable "default-conda-store-namespace" {
   description = "Default conda-store namespace"
   type        = string
 }
+
+variable "terminal_cull_inactive_timeout" {
+  description = "Timeout (in minutess) in which a terminal has been inactive and ready to be culled"
+  type        = number
+  default     = 30
+}
+
+variable "terminal_cull_interval" {
+  description = "The interval (in minutes) on which to check for terminals exceeding the inactive timeout value"
+  type        = number
+  default     = 5
+}
+
+variable "kernel_cull_idle_timeout" {
+  description = "Timeout (in minutes) after which an idle kernel is considered ready to be culled"
+  type        = number
+  default     = 30
+}
+
+variable "kernel_cull_interval" {
+  description = "The interval (in minutes) on which to check for idle kernels exceeding the cull timeout value"
+  type        = number
+  default     = 5
+}
+
+variable "kernel_cull_connected" {
+  description = "Whether to consider culling kernels which have one or more connections"
+  type        = bool
+  default     = true
+}
+
+variable "kernel_cull_busy" {
+  description = "Whether to consider culling kernels which are currently busy running some code"
+  type        = bool
+  default     = false
+}
+
+variable "server_shutdown_no_activity_timeout" {
+  description = "Shut down the server after N minutes with no kernels or terminals running and no activity"
+  type        = number
+  default     = 15
+}

--- a/nebari/template/stages/07-kubernetes-services/variables.tf
+++ b/nebari/template/stages/07-kubernetes-services/variables.tf
@@ -56,3 +56,38 @@ variable "conda-store-service-token-scopes" {
     }
   }
 }
+
+variable "terminal_cull_inactive_timeout" {
+  description = "Timeout (in minutess) in which a terminal has been inactive and ready to be culled"
+  type        = number
+}
+
+variable "terminal_cull_interval" {
+  description = "The interval (in minutes) on which to check for terminals exceeding the inactive timeout value"
+  type        = number
+}
+
+variable "kernel_cull_idle_timeout" {
+  description = "Timeout (in minutes) after which an idle kernel is considered ready to be culled"
+  type        = number
+}
+
+variable "kernel_cull_interval" {
+  description = "The interval (in minutes) on which to check for idle kernels exceeding the cull timeout value"
+  type        = number
+}
+
+variable "kernel_cull_connected" {
+  description = "Whether to consider culling kernels which have one or more connections"
+  type        = bool
+}
+
+variable "kernel_cull_busy" {
+  description = "Whether to consider culling kernels which are currently busy running some code"
+  type        = bool
+}
+
+variable "server_shutdown_no_activity_timeout" {
+  description = "Shut down the server after N minutes with no kernels or terminals running and no activity"
+  type        = number
+}

--- a/nebari/template/stages/07-kubernetes-services/variables.tf
+++ b/nebari/template/stages/07-kubernetes-services/variables.tf
@@ -57,37 +57,22 @@ variable "conda-store-service-token-scopes" {
   }
 }
 
-variable "terminal_cull_inactive_timeout" {
-  description = "Timeout (in minutess) in which a terminal has been inactive and ready to be culled"
-  type        = number
+
+variable "idle-culler-settings" {
+  description = "Idle culler timeout settings (in minutes)"
+  type        = any
 }
 
-variable "terminal_cull_interval" {
-  description = "The interval (in minutes) on which to check for terminals exceeding the inactive timeout value"
-  type        = number
-}
-
-variable "kernel_cull_idle_timeout" {
-  description = "Timeout (in minutes) after which an idle kernel is considered ready to be culled"
-  type        = number
-}
-
-variable "kernel_cull_interval" {
-  description = "The interval (in minutes) on which to check for idle kernels exceeding the cull timeout value"
-  type        = number
-}
-
-variable "kernel_cull_connected" {
-  description = "Whether to consider culling kernels which have one or more connections"
-  type        = bool
-}
-
-variable "kernel_cull_busy" {
-  description = "Whether to consider culling kernels which are currently busy running some code"
-  type        = bool
-}
-
-variable "server_shutdown_no_activity_timeout" {
-  description = "Shut down the server after N minutes with no kernels or terminals running and no activity"
-  type        = number
+# allows us to merge variables set in the nebari-config.yaml with the default values below
+locals {
+  default-idle-culler-settings = {
+    kernel_cull_busy                    = false
+    kernel_cull_connected               = true
+    kernel_cull_idle_timeout            = 15
+    kernel_cull_interval                = 5
+    server_shutdown_no_activity_timeout = 15
+    terminal_cull_inactive_timeout      = 15
+    terminal_cull_interval              = 5
+  }
+  idle-culler-settings = merge(local.default-idle-culler-settings, var.idle-culler-settings)
 }


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://nebari.dev/community
-->

## Reference Issues or PRs

<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create a link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Closes #1283 

This PR makes it so users can configure the JupyterLab idle-culler settings directly from their `nebari-config.yaml`. The pattern that I used to achieve this was with a Terraform [templatefile](https://developer.hashicorp.com/terraform/language/functions/templatefile), which is a pattern that I believe we can use to modify other configuration files in the future (this might include the `.bashrc` and similar files). 

I still need to add documentation for this but to change the idle-culler settings, you can add the following to your `nebari-config.yaml`:

```yaml
jupyterlab:
  idle_culler:
    server_shutdown_no_activity_timeout: 100
    kernel_cull_connected: true
```

Any subset of the idle culler settings can be configured like this. By default, the `jupyterlab` key is not included. 

## What does this implement/fix?

_Put a `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds a feature)
- [ ] Breaking change (fix or feature that would cause existing features not to work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Other (please describe):

## Testing

- [x] Did you test the pull request locally?
- [ ] Did you add new tests?

## Any other comments?

<!--
Please be aware that we are a loose team of volunteers, so patience is necessary;
assistance handling other issues is very welcome.
We value all user contributions. If we are slow to review, either the pull request needs some benchmarking, tinkering,
convincing, etc., or the reviewers are likely busy. In either case,
we ask for your understanding during the
review process.
Thanks for contributing to Nebari 🙏🏼!
-->
