### PR TITLE
Use --quiet flag for conda install in CI

### DIFF
--- a/.github/workflows/kubernetes_test.yaml
+++ b/.github/workflows/kubernetes_test.yaml
@@ -68,7 +68,7 @@ jobs:
           miniconda-version: "latest"
       - name: Install Nebari
         run: |
-          conda install -c anaconda pip
+          conda install --quiet --yes -c anaconda pip
           pip install .[dev]
       - name: Download and Install Kubectl
         run: |

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -51,7 +51,7 @@ jobs:
       - name: Install Nebari
         run: |
           pip install .[dev]
-          conda install conda-build -y
+          conda install --quiet --yes conda-build
       - name: Test Nebari
         run: |
           pytest --version


### PR DESCRIPTION
Per title. Although we definitely want verbose output in CI, `--quiet` is actually harmless:

```
$ conda install --help | grep -e '--quiet'
  -q, --quiet           Do not display progress bar.
```

So this just disables just the progress bars, which create quite a few unnecessary lines. For example: https://github.com/nebari-dev/nebari/actions/runs/4621921970/jobs/8173947067#step:4:646

