### PR TITLE
Adding conda-store as a docker registry within nebari

### DIFF
--- a/nebari/template/stages/07-kubernetes-services/modules/kubernetes/services/conda-store/config/conda_store_config.py
+++ b/nebari/template/stages/07-kubernetes-services/modules/kubernetes/services/conda-store/config/conda_store_config.py
@@ -133,8 +133,16 @@ class KeyCloakAuthentication(GenericOAuthAuthentication):
 
 c.CondaStoreServer.authentication_class = KeyCloakAuthentication
 c.AuthenticationBackend.predefined_tokens = {
-    service_token: service_permissions
-    for service_token, service_permissions in config["service-tokens"].items()
+    config['docker-registry-token']: {
+      "primary_namespace" : "global",
+      "role_bindings" : {
+        "*/*" : ["viewer"],
+      }
+    },
+    **{
+        service_token: service_permissions
+        for service_token, service_permissions in config["service-tokens"].items()
+    }
 }
 
 # ==================================

--- a/nebari/template/stages/07-kubernetes-services/modules/kubernetes/services/conda-store/config/conda_store_config.py
+++ b/nebari/template/stages/07-kubernetes-services/modules/kubernetes/services/conda-store/config/conda_store_config.py
@@ -133,16 +133,16 @@ class KeyCloakAuthentication(GenericOAuthAuthentication):
 
 c.CondaStoreServer.authentication_class = KeyCloakAuthentication
 c.AuthenticationBackend.predefined_tokens = {
-    config['docker-registry-token']: {
-      "primary_namespace" : "global",
-      "role_bindings" : {
-        "*/*" : ["viewer"],
-      }
+    config["docker-registry-token"]: {
+        "primary_namespace": "global",
+        "role_bindings": {
+            "*/*": ["viewer"],
+        },
     },
     **{
         service_token: service_permissions
         for service_token, service_permissions in config["service-tokens"].items()
-    }
+    },
 }
 
 # ==================================

--- a/nebari/template/stages/07-kubernetes-services/variables.tf
+++ b/nebari/template/stages/07-kubernetes-services/variables.tf
@@ -53,7 +53,7 @@ variable "conda-store-service-token-scopes" {
       "role_bindings" : {
         "*/*" : ["viewer"],
       }
-    }
+    },
   }
 }
 


### PR DESCRIPTION
A blocker for allowing conda-store to be a registry for nebari was allowing the kubernetes cluster in an authenticated fashion be able to pull images. This adds the needed kubernetes secret and exposes the registry via port `5000`. 

This feature will only work with trusted https certificates at the moment. So as of now this can not be too tightly coupled to how things are done in nebari since we still use self-signed certificates occasionally. I'm unsure how to solve this in an automated way.