### PR TITLE
improve CLI tests

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,7 +1,4 @@
-import os
 import subprocess
-import typing
-from pathlib import Path
 
 import pytest
 
@@ -10,17 +7,6 @@ from nebari.utils import load_yaml
 
 PROJECT_NAME = "clitest"
 DOMAIN_NAME = "clitest.dev"
-
-
-def run_cli_cmd(command: str, working_dir: typing.Union[str, Path]):
-    """Run the provided CLI command using subprocess."""
-    try:
-        os.chdir(working_dir)
-        subprocess.call(command.split())
-    except subprocess.CalledProcessError:
-        return False
-
-    return True
 
 
 @pytest.mark.parametrize(
@@ -32,28 +18,35 @@ def run_cli_cmd(command: str, working_dir: typing.Union[str, Path]):
 )
 def test_nebari_init(tmp_path, namespace, auth_provider, ci_provider, ssl_cert_email):
     """Test `nebari init` CLI command."""
-    command = f"nebari init local --project {PROJECT_NAME} --domain {DOMAIN_NAME} --disable-prompt"
+    command = [
+        "nebari",
+        "init",
+        "local",
+        f"--project={PROJECT_NAME}",
+        f"--domain={DOMAIN_NAME}",
+        "--disable-prompt",
+    ]
 
     default_values = InitInputs()
 
     if namespace:
-        command += f" --namespace {namespace}"
+        command.append(f"--namespace={namespace}")
     else:
         namespace = default_values.namespace
     if auth_provider:
-        command += f" --auth-provider {auth_provider}"
+        command.append(f"--auth-provider={auth_provider}")
     else:
         auth_provider = default_values.auth_provider
     if ci_provider:
-        command += f" --ci-provider {ci_provider}"
+        command.append(f"--ci-provider={ci_provider}")
     else:
         ci_provider = default_values.ci_provider
     if ssl_cert_email:
-        command += f" --ssl-cert-email {ssl_cert_email}"
+        command.append(f"--ssl-cert-email={ssl_cert_email}")
     else:
         ssl_cert_email = default_values.ssl_cert_email
 
-    assert run_cli_cmd(command, tmp_path)
+    subprocess.run(command, cwd=tmp_path, check=True)
 
     config = load_yaml(tmp_path / "nebari-config.yaml")
 
@@ -67,7 +60,6 @@ def test_nebari_init(tmp_path, namespace, auth_provider, ci_provider, ssl_cert_e
         assert ci_cd.get("type", {}) == ci_provider
     else:
         assert ci_cd == ci_provider
-        ci_cd = config.get("ci_cd", None)
     acme_email = config.get("certificate", None)
     if acme_email:
         assert acme_email.get("acme_email") == ssl_cert_email


### PR DESCRIPTION
## What does this implement/fix?

Our current CLI tests are not sufficient, since our checking logic does not do what it is supposed to be doing. We only catch errors in the subprocess:

https://github.com/nebari-dev/nebari/blob/daecbcf37497b1b8b4e3f0f52667ababf3c023ad/tests/test_cli.py#L15-L23

However, `subprocess.call` does not fail on exit codes > 0:

```bash
$ ls foo
"foo": No such file or directory (os error 2)
$ echo $?
2
$ python -c 'import subprocess; subprocess.call(["ls", "foo"])'
ls: cannot access 'foo': No such file or directory
$ echo $?
0
```

This PR uses [`subprocess.run`](https://docs.python.org/3/library/subprocess.html#subprocess.run) instead, which is the [recommended way](https://docs.python.org/3/library/subprocess.html#using-the-subprocess-module) and has the `check=True` flag to enable error code checking.

_Put a `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds a feature)
- [ ] Breaking change (fix or feature that would cause existing features not to work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Other (please describe):

## Testing

- [x] Did you test the pull request locally?
- [ ] Did you add new tests?
