### PR TITLE
don't set /etc/hosts

### DIFF
--- a/.github/workflows/kubernetes_test.yaml
+++ b/.github/workflows/kubernetes_test.yaml
@@ -90,9 +90,6 @@ jobs:
       - name: Get routing table for docker pods
         run: |
           ip route
-      - name: Add DNS entry to hosts
-        run: |
-          sudo echo "172.18.1.100  github-actions.nebari.dev" | sudo tee -a /etc/hosts
       - name: Initialize Nebari Cloud
         run: |
           mkdir -p local-deployment


### PR DESCRIPTION
## What does this implement/fix?

There are basically two scenarios:

1. We have domain and can set the DNS. In that case there is no need to set `/etc/hosts` since the DNS is handling it for us
2. We don't have a domain. In that case setting `/etc/hosts` is not enough. See https://github.com/nebari-dev/nebari/issues/1703#issuecomment-1502988292 and #1707.

Thus, there is no need to set it at all. This PR removes it from CI to see if anything breaks (it shouldn't). If we move forward here, we also need to send a PR to the docs and remove that section there.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds a feature)
- [ ] Breaking change (fix or feature that would cause existing features not to work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Other (please describe):

## Testing

- [ ] Did you test the pull request locally?
- [ ] Did you add new tests?

