### PR TITLE
Fix? contributor test trigger

### DIFF
--- a/.github/workflows/contributor.yaml
+++ b/.github/workflows/contributor.yaml
@@ -32,7 +32,8 @@ jobs:
 
       - name: C
         if: contains(fromJson('["OWNER", "COLLABORATOR", "MEMBER"]'), github.event.comment.author_association)
-        run: echo ${{ fromJson('["OWNER", "COLLABORATOR", "MEMBER"]') }} | jq
+        run: |
+          echo '["OWNER", "COLLABORATOR", "MEMBER"]' | jq
 
 #  build:
 #    name: Build

--- a/.github/workflows/contributor.yaml
+++ b/.github/workflows/contributor.yaml
@@ -16,15 +16,24 @@ jobs:
         env:
           CTX: ${{ toJSON(github) }}
         run: |
-          set -x
-          A=${{ github.event.issue.pull_request && true}}
-          B=${{ contains(github.event.comment.body, '/bot run tests') }}
-          C1=${{ fromJson('["OWNER", "COLLABORATOR", "MEMBER"]') }}
-          C=${{ contains(fromJson('["OWNER", "COLLABORATOR", "MEMBER"]'), github.event.comment.author_association) }}
-          
-          if [[ A && B && C ]]; then
-            echo "Hooray!"
-          fi
+          exit 0
+
+      - name: A
+        if: github.event.issue.pull_request
+        run: exit 0
+
+      - name: A1
+        if: github.event.issue.pull_request && true
+        run: exit 0
+
+      - name: B
+        if: contains(github.event.comment.body, '/bot run tests')
+        run: exit 0
+
+      - name: C
+        if: contains(fromJson('["OWNER", "COLLABORATOR", "MEMBER"]'), github.event.comment.author_association)
+        run: echo ${{ fromJson('["OWNER", "COLLABORATOR", "MEMBER"]') }} | jq
+
 #  build:
 #    name: Build
 #    if: ${{ github.event.issue.pull_request && contains(github.event.comment.body, '/bot run tests') && contains(fromJson('["OWNER", "COLLABORATOR", "MEMBER"]'), github.event.comment.author_association)}}

--- a/.github/workflows/contributor.yaml
+++ b/.github/workflows/contributor.yaml
@@ -12,12 +12,6 @@ jobs:
   debug:
     runs-on: ubuntu-latest
     steps:
-      - name: parts
-        run: |
-          echo github.event.issue.pull_request=${{ github.event.issue.pull_request }} || true
-          echo contains(github.event.comment.body, '/bot run tests')=${{ contains(github.event.comment.body, '/bot run tests') }} || true
-          echo contains(fromJson('["OWNER", "COLLABORATOR", "MEMBER"]'), github.event.comment.author_association)=${{ contains(fromJson('["OWNER", "COLLABORATOR", "MEMBER"]'), github.event.comment.author_association) }} || true
-
       - name: json
         run: |
           CTX=${{ toJSON(github) }}

--- a/.github/workflows/contributor.yaml
+++ b/.github/workflows/contributor.yaml
@@ -13,21 +13,17 @@ jobs:
     runs-on: ubuntu-latest
     secrets: inherit
     steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-#      - name: parts
-#        run: |
-#          echo github.event.issue.pull_request=${{ github.event.issue.pull_request }} || true
-#          echo contains(github.event.comment.body, '/bot run tests')=${{ contains(github.event.comment.body, '/bot run tests') }} || true
-#          echo contains(fromJson('["OWNER", "COLLABORATOR", "MEMBER"]'), github.event.comment.author_association)=${{ contains(fromJson('["OWNER", "COLLABORATOR", "MEMBER"]'), github.event.comment.author_association) }} || true
-#
-#      - name: json
-#        run: |
-#          CTX=${{ toJSON(github) }}
-#          echo "${CTX}"
-#          echo "${CTX}" | jq
+      - name: parts
+        run: |
+          echo github.event.issue.pull_request=${{ github.event.issue.pull_request }} || true
+          echo contains(github.event.comment.body, '/bot run tests')=${{ contains(github.event.comment.body, '/bot run tests') }} || true
+          echo contains(fromJson('["OWNER", "COLLABORATOR", "MEMBER"]'), github.event.comment.author_association)=${{ contains(fromJson('["OWNER", "COLLABORATOR", "MEMBER"]'), github.event.comment.author_association) }} || true
+
+      - name: json
+        run: |
+          CTX=${{ toJSON(github) }}
+          echo "${CTX}"
+          echo "${CTX}" | jq
 
   build:
     name: Build

--- a/.github/workflows/contributor.yaml
+++ b/.github/workflows/contributor.yaml
@@ -11,18 +11,23 @@ permissions:
 jobs:
   debug:
     runs-on: ubuntu-latest
+    secrets: inherit
     steps:
-      - name: parts
-        run: |
-          echo github.event.issue.pull_request=${{ github.event.issue.pull_request }} || true
-          echo contains(github.event.comment.body, '/bot run tests')=${{ contains(github.event.comment.body, '/bot run tests') }} || true
-          echo contains(fromJson('["OWNER", "COLLABORATOR", "MEMBER"]'), github.event.comment.author_association)=${{ contains(fromJson('["OWNER", "COLLABORATOR", "MEMBER"]'), github.event.comment.author_association) }} || true
-
-      - name: json
-        run: |
-          CTX=${{ toJSON(github) }}
-          echo "${CTX}"
-          echo "${CTX}" | jq
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+#      - name: parts
+#        run: |
+#          echo github.event.issue.pull_request=${{ github.event.issue.pull_request }} || true
+#          echo contains(github.event.comment.body, '/bot run tests')=${{ contains(github.event.comment.body, '/bot run tests') }} || true
+#          echo contains(fromJson('["OWNER", "COLLABORATOR", "MEMBER"]'), github.event.comment.author_association)=${{ contains(fromJson('["OWNER", "COLLABORATOR", "MEMBER"]'), github.event.comment.author_association) }} || true
+#
+#      - name: json
+#        run: |
+#          CTX=${{ toJSON(github) }}
+#          echo "${CTX}"
+#          echo "${CTX}" | jq
 
   build:
     name: Build
@@ -64,7 +69,7 @@ jobs:
   provider-tests:
     name: "Contributor #${{ github.event.issue.number }}"
     if: ${{ github.event.issue.pull_request && contains(github.event.comment.body, '/bot run tests') && contains(fromJson('["OWNER", "COLLABORATOR", "MEMBER"]'), github.event.comment.author_association)}}
-    uses: nebari-dev/nebari/.github/workflows/test-provider.yaml@release/2022.4.1
+    uses: nebari-dev/nebari/.github/workflows/test-provider.yaml@release/2023.4.1
     with:
       pr_number: ${{ github.event.issue.number }}
     secrets: inherit

--- a/.github/workflows/contributor.yaml
+++ b/.github/workflows/contributor.yaml
@@ -12,6 +12,11 @@ jobs:
   trigger-contributor-tests:
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
       #- name: Comment is not on a PR
       #  if: ${{ !github.event.issue.pull_request }}
       #  run: exit 1

--- a/.github/workflows/contributor.yaml
+++ b/.github/workflows/contributor.yaml
@@ -11,7 +11,6 @@ permissions:
 jobs:
   debug:
     runs-on: ubuntu-latest
-    secrets: inherit
     steps:
       - name: parts
         run: |

--- a/.github/workflows/contributor.yaml
+++ b/.github/workflows/contributor.yaml
@@ -13,15 +13,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Comment is not on a PR
-        if: !github.event.issue.pull_request
+        if: ${{ !github.event.issue.pull_request }}
         run: exit 1
 
       - name: Comment does not contains the trigger phrase
-        if: !contains(github.event.comment.body, '/bot run tests')
+        if: ${{ !contains(github.event.comment.body, '/bot run tests') }}
         run: exit 1
 
       - name: Author of comment has insufficient permissions
-        if: !contains(fromJson('["OWNER", "COLLABORATOR", "MEMBER"]'), github.event.comment.author_association)
+        if: ${{ !contains(fromJson('["OWNER", "COLLABORATOR", "MEMBER"]'), github.event.comment.author_association) }}
         run: exit 1
 
   build:

--- a/.github/workflows/contributor.yaml
+++ b/.github/workflows/contributor.yaml
@@ -13,15 +13,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Comment is not on a PR
-        if: ! github.event.issue.pull_request
+        if: !github.event.issue.pull_request
         run: exit 1
 
       - name: Comment does not contains the trigger phrase
-        if: ! contains(github.event.comment.body, '/bot run tests')
+        if: !contains(github.event.comment.body, '/bot run tests')
         run: exit 1
 
       - name: Author of comment has insufficient permissions
-        if: ! contains(fromJson('["OWNER", "COLLABORATOR", "MEMBER"]'), github.event.comment.author_association)
+        if: !contains(fromJson('["OWNER", "COLLABORATOR", "MEMBER"]'), github.event.comment.author_association)
         run: exit 1
 
   build:

--- a/.github/workflows/contributor.yaml
+++ b/.github/workflows/contributor.yaml
@@ -9,6 +9,21 @@ permissions:
   pull-requests: write
 
 jobs:
+  debug:
+    runs-on: ubuntu-latest
+    steps:
+      - name: parts
+        run: |
+          echo github.event.issue.pull_request=${{ github.event.issue.pull_request }} || true
+          echo contains(github.event.comment.body, '/bot run tests')=${{ contains(github.event.comment.body, '/bot run tests') }} || true
+          echo contains(fromJson('["OWNER", "COLLABORATOR", "MEMBER"]'), github.event.comment.author_association)=${{ contains(fromJson('["OWNER", "COLLABORATOR", "MEMBER"]'), github.event.comment.author_association) }} || true
+
+      - name: json
+        run: |
+          CTX=${{ toJSON(github) }}
+          echo "${CTX}"
+          echo "${CTX}" | jq
+
   build:
     name: Build
     if: ${{ github.event.issue.pull_request && contains(github.event.comment.body, '/bot run tests') && contains(fromJson('["OWNER", "COLLABORATOR", "MEMBER"]'), github.event.comment.author_association)}}
@@ -33,7 +48,7 @@ jobs:
   kubernetes-tests:
     name: "Contributor #${{ github.event.issue.number }}"
     if: ${{ github.event.issue.pull_request && contains(github.event.comment.body, '/bot run tests') && contains(fromJson('["OWNER", "COLLABORATOR", "MEMBER"]'), github.event.comment.author_association)}}
-    uses: nebari-dev/nebari/.github/workflows/kubernetes_test.yaml@release/2022.11.1
+    uses: nebari-dev/nebari/.github/workflows/kubernetes_test.yaml@release/2023.4.1
     with:
       pr_number: ${{ github.event.issue.number }}
     secrets: inherit
@@ -41,7 +56,7 @@ jobs:
   infracost-tests:
     name: "Contributor #${{ github.event.issue.number }}"
     if: ${{ github.event.issue.pull_request && contains(github.event.comment.body, '/bot run tests') && contains(fromJson('["OWNER", "COLLABORATOR", "MEMBER"]'), github.event.comment.author_association)}}
-    uses: nebari-dev/nebari/.github/workflows/infracost.yml@release/2022.11.1
+    uses: nebari-dev/nebari/.github/workflows/infracost.yml@release/2023.4.1
     with:
       pr_number: ${{ github.event.issue.number }}
     secrets: inherit
@@ -49,7 +64,7 @@ jobs:
   provider-tests:
     name: "Contributor #${{ github.event.issue.number }}"
     if: ${{ github.event.issue.pull_request && contains(github.event.comment.body, '/bot run tests') && contains(fromJson('["OWNER", "COLLABORATOR", "MEMBER"]'), github.event.comment.author_association)}}
-    uses: nebari-dev/nebari/.github/workflows/test-provider.yaml@release/2022.11.1
+    uses: nebari-dev/nebari/.github/workflows/test-provider.yaml@release/2022.4.1
     with:
       pr_number: ${{ github.event.issue.number }}
     secrets: inherit

--- a/.github/workflows/contributor.yaml
+++ b/.github/workflows/contributor.yaml
@@ -12,17 +12,17 @@ jobs:
   trigger-contributor-tests:
     runs-on: ubuntu-latest
     steps:
-      - name: Comment is not on a PR
-        if: ${{ !github.event.issue.pull_request }}
-        run: exit 1
+      #- name: Comment is not on a PR
+      #  if: ${{ !github.event.issue.pull_request }}
+      #  run: exit 1
 
-      - name: Comment does not contains the trigger phrase
-        if: ${{ !contains(github.event.comment.body, '/bot run tests') }}
-        run: exit 1
+      #- name: Comment does not contains the trigger phrase
+      #  if: ${{ !contains(github.event.comment.body, '/bot run tests') }}
+      #  run: exit 1
 
-      - name: Author of comment has insufficient permissions
-        if: ${{ !contains(fromJson('["OWNER", "COLLABORATOR", "MEMBER"]'), github.event.comment.author_association) }}
-        run: exit 1
+      #- name: Author of comment has insufficient permissions
+      #  if: ${{ !contains(fromJson('["OWNER", "COLLABORATOR", "MEMBER"]'), github.event.comment.author_association) }}
+      #  run: exit 1
 
       - name: Setup tmate session
         uses: mxschmitt/action-tmate@v3

--- a/.github/workflows/contributor.yaml
+++ b/.github/workflows/contributor.yaml
@@ -13,11 +13,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: json
+        env:
+          CTX: ${{ toJSON(github) }}
         run: |
-          CTX=${{ toJSON(github) }}
-          echo "${CTX}"
-          echo "${CTX}" | jq
-
+          set -x
+          A=${{ github.event.issue.pull_request && true}}
+          B=${{ contains(github.event.comment.body, '/bot run tests') }}
+          C1=${{ fromJson('["OWNER", "COLLABORATOR", "MEMBER"]') }}
+          C=${{ contains(fromJson('["OWNER", "COLLABORATOR", "MEMBER"]'), github.event.comment.author_association) }}
+          D=${{ A && B && C }}
+          
+          E=${{ contains(fromJson('["OWNER", "COLLABORATOR", "MEMBER"]'), github.event.issue.author_association) }}
+          F=${{ A && (E || (B && C))}}
 #  build:
 #    name: Build
 #    if: ${{ github.event.issue.pull_request && contains(github.event.comment.body, '/bot run tests') && contains(fromJson('["OWNER", "COLLABORATOR", "MEMBER"]'), github.event.comment.author_association)}}

--- a/.github/workflows/contributor.yaml
+++ b/.github/workflows/contributor.yaml
@@ -24,6 +24,9 @@ jobs:
         if: ${{ !contains(fromJson('["OWNER", "COLLABORATOR", "MEMBER"]'), github.event.comment.author_association) }}
         run: exit 1
 
+      - name: Setup tmate session
+        uses: mxschmitt/action-tmate@v3
+
   build:
     needs: trigger-contributor-tests
     name: Build

--- a/.github/workflows/contributor.yaml
+++ b/.github/workflows/contributor.yaml
@@ -26,52 +26,46 @@ jobs:
 
   build:
     needs: trigger-contributor-tests
+    name: Build
+    if: ${{ github.event.issue.pull_request && contains(github.event.comment.body, '/bot run tests') && contains(fromJson('["OWNER", "COLLABORATOR", "MEMBER"]'), github.event.comment.author_association)}}
     runs-on: ubuntu-latest
-    steps:
-      - name: foo
-        run: echo bar
 
-#  build:
-#    name: Build
-#    if: ${{ github.event.issue.pull_request && contains(github.event.comment.body, '/bot run tests') && contains(fromJson('["OWNER", "COLLABORATOR", "MEMBER"]'), github.event.comment.author_association)}}
-#    runs-on: ubuntu-latest
-#
-#    steps:
-#      - name: Checkout
-#        uses: actions/checkout@v3
-#        with:
-#          token: ${{ secrets.GITHUB_TOKEN }}
-#
-#      - name: Create comment on the PR
-#        uses: peter-evans/create-or-update-comment@v2
-#        with:
-#          issue-number: ${{ github.event.issue.number }}
-#          body: |
-#            Contributor Tests Triggered by @${{ github.event.comment.user.login }}
-#            - via [comment](${{ github.event.comment.html_url }})
-#            - Build is running [here](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
-#          reactions: 'rocket'
-#
-#  kubernetes-tests:
-#    name: "Contributor #${{ github.event.issue.number }}"
-#    if: ${{ github.event.issue.pull_request && contains(github.event.comment.body, '/bot run tests') && contains(fromJson('["OWNER", "COLLABORATOR", "MEMBER"]'), github.event.comment.author_association)}}
-#    uses: nebari-dev/nebari/.github/workflows/kubernetes_test.yaml@release/2023.4.1
-#    with:
-#      pr_number: ${{ github.event.issue.number }}
-#    secrets: inherit
-#
-#  infracost-tests:
-#    name: "Contributor #${{ github.event.issue.number }}"
-#    if: ${{ github.event.issue.pull_request && contains(github.event.comment.body, '/bot run tests') && contains(fromJson('["OWNER", "COLLABORATOR", "MEMBER"]'), github.event.comment.author_association)}}
-#    uses: nebari-dev/nebari/.github/workflows/infracost.yml@release/2023.4.1
-#    with:
-#      pr_number: ${{ github.event.issue.number }}
-#    secrets: inherit
-#
-#  provider-tests:
-#    name: "Contributor #${{ github.event.issue.number }}"
-#    if: ${{ github.event.issue.pull_request && contains(github.event.comment.body, '/bot run tests') && contains(fromJson('["OWNER", "COLLABORATOR", "MEMBER"]'), github.event.comment.author_association)}}
-#    uses: nebari-dev/nebari/.github/workflows/test-provider.yaml@release/2023.4.1
-#    with:
-#      pr_number: ${{ github.event.issue.number }}
-#    secrets: inherit
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create comment on the PR
+        uses: peter-evans/create-or-update-comment@v2
+        with:
+          issue-number: ${{ github.event.issue.number }}
+          body: |
+            Contributor Tests Triggered by @${{ github.event.comment.user.login }}
+            - via [comment](${{ github.event.comment.html_url }})
+            - Build is running [here](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
+          reactions: 'rocket'
+
+  kubernetes-tests:
+    needs: trigger-contributor-tests
+    name: "Contributor #${{ github.event.issue.number }}"
+    uses: nebari-dev/nebari/.github/workflows/kubernetes_test.yaml@release/2023.4.1
+    with:
+      pr_number: ${{ github.event.issue.number }}
+    secrets: inherit
+
+  infracost-tests:
+    needs: trigger-contributor-tests
+    name: "Contributor #${{ github.event.issue.number }}"
+    uses: nebari-dev/nebari/.github/workflows/infracost.yml@release/2023.4.1
+    with:
+      pr_number: ${{ github.event.issue.number }}
+    secrets: inherit
+
+  provider-tests:
+    needs: trigger-contributor-tests
+    name: "Contributor #${{ github.event.issue.number }}"
+    uses: nebari-dev/nebari/.github/workflows/test-provider.yaml@release/2023.4.1
+    with:
+      pr_number: ${{ github.event.issue.number }}
+    secrets: inherit

--- a/.github/workflows/contributor.yaml
+++ b/.github/workflows/contributor.yaml
@@ -21,10 +21,10 @@ jobs:
           B=${{ contains(github.event.comment.body, '/bot run tests') }}
           C1=${{ fromJson('["OWNER", "COLLABORATOR", "MEMBER"]') }}
           C=${{ contains(fromJson('["OWNER", "COLLABORATOR", "MEMBER"]'), github.event.comment.author_association) }}
-          D=${{ A && B && C }}
           
-          E=${{ contains(fromJson('["OWNER", "COLLABORATOR", "MEMBER"]'), github.event.issue.author_association) }}
-          F=${{ A && (E || (B && C))}}
+          if [[ A && B && C ]]; then
+            echo "Hooray!"
+          fi
 #  build:
 #    name: Build
 #    if: ${{ github.event.issue.pull_request && contains(github.event.comment.body, '/bot run tests') && contains(fromJson('["OWNER", "COLLABORATOR", "MEMBER"]'), github.event.comment.author_association)}}

--- a/.github/workflows/contributor.yaml
+++ b/.github/workflows/contributor.yaml
@@ -9,31 +9,27 @@ permissions:
   pull-requests: write
 
 jobs:
-  debug:
+  trigger-contributor-tests:
     runs-on: ubuntu-latest
     steps:
-      - name: json
-        env:
-          CTX: ${{ toJSON(github) }}
-        run: |
-          exit 0
+      - name: Comment is not on a PR
+        if: ! github.event.issue.pull_request
+        run: exit 1
 
-      - name: A
-        if: github.event.issue.pull_request
-        run: exit 0
+      - name: Comment does not contains the trigger phrase
+        if: ! contains(github.event.comment.body, '/bot run tests')
+        run: exit 1
 
-      - name: A1
-        if: github.event.issue.pull_request && true
-        run: exit 0
+      - name: Author of comment has insufficient permissions
+        if: ! contains(fromJson('["OWNER", "COLLABORATOR", "MEMBER"]'), github.event.comment.author_association)
+        run: exit 1
 
-      - name: B
-        if: contains(github.event.comment.body, '/bot run tests')
-        run: exit 0
-
-      - name: C
-        if: contains(fromJson('["OWNER", "COLLABORATOR", "MEMBER"]'), github.event.comment.author_association)
-        run: |
-          echo '["OWNER", "COLLABORATOR", "MEMBER"]' | jq
+  build:
+    needs: trigger-contributor-tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: foo
+        run: echo bar
 
 #  build:
 #    name: Build

--- a/.github/workflows/contributor.yaml
+++ b/.github/workflows/contributor.yaml
@@ -17,20 +17,17 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      #- name: Comment is not on a PR
-      #  if: ${{ !github.event.issue.pull_request }}
-      #  run: exit 1
+      - name: Comment is not on a PR
+        if: ${{ !github.event.issue.pull_request }}
+        run: exit 1
 
-      #- name: Comment does not contains the trigger phrase
-      #  if: ${{ !contains(github.event.comment.body, '/bot run tests') }}
-      #  run: exit 1
+      - name: Comment does not contains the trigger phrase
+        if: ${{ !contains(github.event.comment.body, '/bot run tests') }}
+        run: exit 1
 
-      #- name: Author of comment has insufficient permissions
-      #  if: ${{ !contains(fromJson('["OWNER", "COLLABORATOR", "MEMBER"]'), github.event.comment.author_association) }}
-      #  run: exit 1
-
-      - name: Setup tmate session
-        uses: mxschmitt/action-tmate@v3
+      - name: Author of comment has insufficient permissions
+        if: ${{ !contains(fromJson('["OWNER", "COLLABORATOR", "MEMBER"]'), github.event.comment.author_association) }}
+        run: exit 1
 
   build:
     needs: trigger-contributor-tests

--- a/.github/workflows/contributor.yaml
+++ b/.github/workflows/contributor.yaml
@@ -24,47 +24,47 @@ jobs:
           echo "${CTX}"
           echo "${CTX}" | jq
 
-  build:
-    name: Build
-    if: ${{ github.event.issue.pull_request && contains(github.event.comment.body, '/bot run tests') && contains(fromJson('["OWNER", "COLLABORATOR", "MEMBER"]'), github.event.comment.author_association)}}
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Create comment on the PR
-        uses: peter-evans/create-or-update-comment@v2
-        with:
-          issue-number: ${{ github.event.issue.number }}
-          body: |
-            Contributor Tests Triggered by @${{ github.event.comment.user.login }}
-            - via [comment](${{ github.event.comment.html_url }})
-            - Build is running [here](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
-          reactions: 'rocket'
-
-  kubernetes-tests:
-    name: "Contributor #${{ github.event.issue.number }}"
-    if: ${{ github.event.issue.pull_request && contains(github.event.comment.body, '/bot run tests') && contains(fromJson('["OWNER", "COLLABORATOR", "MEMBER"]'), github.event.comment.author_association)}}
-    uses: nebari-dev/nebari/.github/workflows/kubernetes_test.yaml@release/2023.4.1
-    with:
-      pr_number: ${{ github.event.issue.number }}
-    secrets: inherit
-
-  infracost-tests:
-    name: "Contributor #${{ github.event.issue.number }}"
-    if: ${{ github.event.issue.pull_request && contains(github.event.comment.body, '/bot run tests') && contains(fromJson('["OWNER", "COLLABORATOR", "MEMBER"]'), github.event.comment.author_association)}}
-    uses: nebari-dev/nebari/.github/workflows/infracost.yml@release/2023.4.1
-    with:
-      pr_number: ${{ github.event.issue.number }}
-    secrets: inherit
-
-  provider-tests:
-    name: "Contributor #${{ github.event.issue.number }}"
-    if: ${{ github.event.issue.pull_request && contains(github.event.comment.body, '/bot run tests') && contains(fromJson('["OWNER", "COLLABORATOR", "MEMBER"]'), github.event.comment.author_association)}}
-    uses: nebari-dev/nebari/.github/workflows/test-provider.yaml@release/2023.4.1
-    with:
-      pr_number: ${{ github.event.issue.number }}
-    secrets: inherit
+#  build:
+#    name: Build
+#    if: ${{ github.event.issue.pull_request && contains(github.event.comment.body, '/bot run tests') && contains(fromJson('["OWNER", "COLLABORATOR", "MEMBER"]'), github.event.comment.author_association)}}
+#    runs-on: ubuntu-latest
+#
+#    steps:
+#      - name: Checkout
+#        uses: actions/checkout@v3
+#        with:
+#          token: ${{ secrets.GITHUB_TOKEN }}
+#
+#      - name: Create comment on the PR
+#        uses: peter-evans/create-or-update-comment@v2
+#        with:
+#          issue-number: ${{ github.event.issue.number }}
+#          body: |
+#            Contributor Tests Triggered by @${{ github.event.comment.user.login }}
+#            - via [comment](${{ github.event.comment.html_url }})
+#            - Build is running [here](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
+#          reactions: 'rocket'
+#
+#  kubernetes-tests:
+#    name: "Contributor #${{ github.event.issue.number }}"
+#    if: ${{ github.event.issue.pull_request && contains(github.event.comment.body, '/bot run tests') && contains(fromJson('["OWNER", "COLLABORATOR", "MEMBER"]'), github.event.comment.author_association)}}
+#    uses: nebari-dev/nebari/.github/workflows/kubernetes_test.yaml@release/2023.4.1
+#    with:
+#      pr_number: ${{ github.event.issue.number }}
+#    secrets: inherit
+#
+#  infracost-tests:
+#    name: "Contributor #${{ github.event.issue.number }}"
+#    if: ${{ github.event.issue.pull_request && contains(github.event.comment.body, '/bot run tests') && contains(fromJson('["OWNER", "COLLABORATOR", "MEMBER"]'), github.event.comment.author_association)}}
+#    uses: nebari-dev/nebari/.github/workflows/infracost.yml@release/2023.4.1
+#    with:
+#      pr_number: ${{ github.event.issue.number }}
+#    secrets: inherit
+#
+#  provider-tests:
+#    name: "Contributor #${{ github.event.issue.number }}"
+#    if: ${{ github.event.issue.pull_request && contains(github.event.comment.body, '/bot run tests') && contains(fromJson('["OWNER", "COLLABORATOR", "MEMBER"]'), github.event.comment.author_association)}}
+#    uses: nebari-dev/nebari/.github/workflows/test-provider.yaml@release/2023.4.1
+#    with:
+#      pr_number: ${{ github.event.issue.number }}
+#    secrets: inherit


### PR DESCRIPTION
## What does this implement/fix?

As seen in #1711 neither my maintainer status nor @iameskild's comment triggered the contributor tests. However, they are required by our branch protection rules. Meaning, #1711 is effectively stuck right now and cannot be merged. 

As explained in https://github.com/nebari-dev/nebari/pull/1734#issuecomment-1517695618, it is a pain to debug workflows that trigger on comments since they don't use the workflow file from the current PR, but only the one from the default branch. Thus, we probably need to merge this PR and try afterwards. I did that in my fork and it worked.

This PR does two things:

1. Instead of having one large condition, it is split in multiple atomic ones. Since we `&&` them together anyway, this can be trivially achieved.
2. Instead of having an `if:` trigger on multiple jobs, we define one "pre-job" and require that on all others through the `needs:` key. That makes it a lot easier if we ever want to change the condition.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds a feature)
- [ ] Breaking change (fix or feature that would cause existing features not to work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Other (please describe):

## Testing

- [x] Did you test the pull request locally?
- [ ] Did you add new tests?
