### PR TITLE
add more debug output to contributor test trigger

### DIFF
--- a/.github/workflows/contributor.yaml
+++ b/.github/workflows/contributor.yaml
@@ -23,11 +23,15 @@ jobs:
 
       - name: Comment does not contains the trigger phrase
         if: ${{ !contains(github.event.comment.body, '/bot run tests') }}
-        run: exit 1
+        run: |
+          echo ${{ github.event.comment.body }}
+          exit 1
 
       - name: Author of comment has insufficient permissions
         if: ${{ !contains(fromJson('["OWNER", "COLLABORATOR", "MEMBER"]'), github.event.comment.author_association) }}
-        run: exit 1
+        run: |
+          echo ${{ github.event.comment.body }}
+          exit 1
 
   build:
     needs: trigger-contributor-tests


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://nebari.dev/community
-->

## Reference Issues or PRs

<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create a link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

## What does this implement/fix?

It seems neither [I](https://github.com/nebari-dev/nebari/actions/runs/4854764166/jobs/8652518957#step:5:5) nor [@iameskild](https://github.com/nebari-dev/nebari/actions/runs/4854748098/jobs/8652486760#step:5:5) have permissions to trigger the contributor tests through a bot comment. Most likely, our check is not set up properly. This PR adds some debug outputs so we can see what role we actually need to check for.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds a feature)
- [ ] Breaking change (fix or feature that would cause existing features not to work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Other (please describe):

## Testing

- [ ] Did you test the pull request locally?
- [ ] Did you add new tests?

## Any other comments?

<!--
Please be aware that we are a loose team of volunteers, so patience is necessary;
assistance handling other issues is very welcome.
We value all user contributions. If we are slow to review, either the pull request needs some benchmarking, tinkering,
convincing, etc., or the reviewers are likely busy. In either case,
we ask for your understanding during the
review process.
Thanks for contributing to Nebari 🙏🏼!
-->
