### PR TITLE
use conda forge explicitly in conda build test

### DIFF
--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -55,7 +55,7 @@ def test_build_by_conda_forge(tmp_path):
         meta_loc = tmp_path / "nebari"
         # try to run conda build to build package from meta.yaml
         subprocess.run(
-            ["conda", "build", meta_loc],
+            ["conda", "build", "--channel=conda-forge", meta_loc],
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             check=True,


### PR DESCRIPTION
## What does this implement/fix?

This PR adds `--channel=conda-forge` explicitly to the `conda build` we are running as part of our tests. Right now our CI relies on this being set in the `conda` configuration file:

https://github.com/nebari-dev/nebari/blob/6b38c8c3215b3ce7683b4c83fe2ecb9aa79c34ac/.github/workflows/test.yaml#L52

However, we cannot depend on this being the case locally for all other devs as well. Without setting the channel explicitly, `conda build` will try to pull from the `defaults` channel and fail, since it doesn't contain everything we need.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds a feature)
- [ ] Breaking change (fix or feature that would cause existing features not to work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Other (please describe):

## Testing

- [x] Did you test the pull request locally?
- [ ] Did you add new tests?