### PR TITLE
improve pre-commit run on GHA

### DIFF
--- a/.github/workflows/run-precommit.yaml
+++ b/.github/workflows/run-precommit.yaml
@@ -19,11 +19,7 @@ jobs:
       - name: Checkout repository 🔔
         uses: actions/checkout@v3
 
-      # https://github.com/pre-commit/action to enable cache
-      - uses: pre-commit/action@v3.0.0
-
-      - name: Install pre-commit 📦
-        run: pip install pre-commit
-
       - name: Run terraform pre-commit ⚡️
-        run: pre-commit run terraform_fmt
+        uses: pre-commit/action@v3.0.0
+        with:
+          extra_args: --all-files terraform_fmt

--- a/nebari/template/stages/01-terraform-state/aws/main.tf
+++ b/nebari/template/stages/01-terraform-state/aws/main.tf
@@ -5,7 +5,7 @@ variable "name" {
 
 variable "namespace" {
   description = "Namespace to create Kubernetes resources"
-  type= string
+  type        = string
 }
 
 module "terraform-state" {

--- a/nebari/template/stages/01-terraform-state/aws/main.tf
+++ b/nebari/template/stages/01-terraform-state/aws/main.tf
@@ -5,7 +5,7 @@ variable "name" {
 
 variable "namespace" {
   description = "Namespace to create Kubernetes resources"
-  type        = string
+  type= string
 }
 
 module "terraform-state" {


### PR DESCRIPTION
The comment

https://github.com/nebari-dev/nebari/blob/ac981ea6fe535cdc4592bffd60a49fe9ab137028/.github/workflows/run-precommit.yaml#L22-L23

is not the full picture. The action also [installs `pre-commit` and runs it against all files by default](https://github.com/pre-commit/action/blob/5f528da5c95691c4cf42ff76a4d10854b62cbb82/action.yml#L11-L20). Meaning, we are currently installing `pre-commit` for nothing 

https://github.com/nebari-dev/nebari/blob/ac981ea6fe535cdc4592bffd60a49fe9ab137028/.github/workflows/run-precommit.yaml#L25-L26

and running the `terraform_fmt` hook twice:

https://github.com/nebari-dev/nebari/blob/ac981ea6fe535cdc4592bffd60a49fe9ab137028/.github/workflows/run-precommit.yaml#L28-L29

This PR improves this by only running the `terraform_fmt` hook through the action.