### PR TITLE
make domain optional

### DIFF
--- a/nebari/cli/init.py
+++ b/nebari/cli/init.py
@@ -368,15 +368,20 @@ def guided_init_wizard(ctx: typer.Context, guided_init: str):
         # DOMAIN NAME
         rich.print(
             (
-                "\n\n 🪴  Great! Now you need to provide a valid domain name (i.e. the URL) to access your Nebri instance. "
-                "This should be a domain that you own.\n\n"
+                "\n\n 🪴  Great! Now you can provide a valid domain name (i.e. the URL) to access your Nebari instance. "
+                "This should be a domain that you own. FIXME Default is the IP of the load balancer\n\n"
             )
         )
-        inputs.domain_name = questionary.text(
-            "What domain name would you like to use?",
-            qmark=qmark,
-            validate=lambda text: True if len(text) > 0 else "Please enter a value",
-        ).unsafe_ask()
+        inputs.domain_name = (
+            questionary.text(
+                "What domain name would you like to use?",
+                qmark=qmark,
+            ).unsafe_ask()
+            or None
+        )
+
+        print("#" * 60)
+        print(repr(inputs.domain_name))
 
         # AUTH PROVIDER
         rich.print(
@@ -466,27 +471,28 @@ def guided_init_wizard(ctx: typer.Context, guided_init: str):
                 inputs.ci_provider = CiEnum.gitlab_ci.value.lower()
 
         # SSL CERTIFICATE
-        rich.print(
-            (
-                "\n\n 🪴  This next section is [italic]optional[/italic] but recommended. If you want your Nebari domain to use a Let's Encrypt SSL certificate, "
-                "all we need is an email address from you.\n\n"
+        if inputs.domain_name:
+            rich.print(
+                (
+                    "\n\n 🪴  This next section is [italic]optional[/italic] but recommended. If you want your Nebari domain to use a Let's Encrypt SSL certificate, "
+                    "all we need is an email address from you.\n\n"
+                )
             )
-        )
-        ssl_cert = questionary.confirm(
-            "Would you like to add a Let's Encrypt SSL certificate to your domain?",
-            default=False,
-            qmark=qmark,
-            auto_enter=False,
-        ).unsafe_ask()
-
-        if ssl_cert:
-            inputs.ssl_cert_email = questionary.text(
-                "Which email address should Let's Encrypt associate the certificate with?",
+            ssl_cert = questionary.confirm(
+                "Would you like to add a Let's Encrypt SSL certificate to your domain?",
+                default=False,
                 qmark=qmark,
+                auto_enter=False,
             ).unsafe_ask()
 
-            if not disable_checks:
-                check_ssl_cert_email(ctx, ssl_cert_email=inputs.ssl_cert_email)
+            if ssl_cert:
+                inputs.ssl_cert_email = questionary.text(
+                    "Which email address should Let's Encrypt associate the certificate with?",
+                    qmark=qmark,
+                ).unsafe_ask()
+
+                if not disable_checks:
+                    check_ssl_cert_email(ctx, ssl_cert_email=inputs.ssl_cert_email)
 
         # ADVANCED FEATURES
         rich.print(
@@ -544,6 +550,8 @@ def guided_init_wizard(ctx: typer.Context, guided_init: str):
                     return b.format(key=key, value=value).replace("_", "-")
                 if isinstance(value, bool) and value:
                     return b.format(key=key, value=value).replace("_", "-")
+
+        print(inputs.dict())
 
         cmds = " ".join(
             [_ for _ in [if_used(_) for _ in inputs.dict().keys()] if _ is not None]

--- a/nebari/cli/main.py
+++ b/nebari/cli/main.py
@@ -114,8 +114,8 @@ def init(
         "-p",
         callback=check_project_name,
     ),
-    domain_name: str = typer.Option(
-        ...,
+    domain_name: Optional[str] = typer.Option(
+        None,
         "--domain-name",
         "--domain",
         "-d",

--- a/nebari/deploy.py
+++ b/nebari/deploy.py
@@ -104,7 +104,7 @@ def provision_ingress_dns(
     ip_or_name = stage_outputs[directory]["load_balancer_address"]["value"]
     ip_or_hostname = ip_or_name["hostname"] or ip_or_name["ip"]
 
-    if dns_auto_provision and dns_provider == "cloudflare":
+    if config["domain"] and dns_auto_provision and dns_provider == "cloudflare":
         record_name, zone_name = (
             config["domain"].split(".")[:-2],
             config["domain"].split(".")[-2:],
@@ -124,6 +124,8 @@ def provision_ingress_dns(
             logger.info(
                 f"Couldn't update the DNS record for cloud provider: {config['provider']}"
             )
+    elif not config["domain"]:
+        config["domain"] = ip_or_hostname
     elif not disable_prompt:
         input(
             f"Take IP Address {ip_or_hostname} and update DNS to point to "

--- a/nebari/initialize.py
+++ b/nebari/initialize.py
@@ -362,8 +362,6 @@ def render_config(
             "namespace should contain only letters and hyphens/underscores (but not at the start or end)"
         )
 
-    if nebari_domain is None and not disable_prompt:
-        nebari_domain = input("Provide domain: ")
     config["domain"] = nebari_domain
 
     # In nebari_version only use major.minor.patch version - drop any pre/post/dev suffixes

--- a/nebari/schema.py
+++ b/nebari/schema.py
@@ -558,7 +558,7 @@ def project_name_convention(value: typing.Any, values):
 class InitInputs(Base):
     cloud_provider: typing.Type[ProviderEnum] = "local"
     project_name: str = ""
-    domain_name: str = ""
+    domain_name: typing.Optional[str] = None
     namespace: typing.Optional[letter_dash_underscore_pydantic] = "dev"
     auth_provider: typing.Type[AuthenticationEnum] = "password"
     auth_auto_provision: bool = False
@@ -577,7 +577,7 @@ class Main(Base):
     namespace: typing.Optional[letter_dash_underscore_pydantic]
     nebari_version: str = ""
     ci_cd: typing.Optional[CICD]
-    domain: str
+    domain: typing.Optional[str]
     terraform_state: typing.Optional[TerraformState]
     certificate: Certificate
     helm_extensions: typing.Optional[typing.List[HelmExtension]]


### PR DESCRIPTION
## Reference Issues or PRs

Closes #1707.

## What does this implement/fix?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds a feature)
- [ ] Breaking change (fix or feature that would cause existing features not to work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Other (please describe):

## Testing

- [x] Did you test the pull request locally?
- [ ] Did you add new tests?

## Any other comments?

`nebari init` (with or without `--guided-init`) and `nebari deploy` work fine. However we get problems for everything else since we never write back the IP of the load balancer that we find during deploy. I think we have two options here:

1. Write back the IP back. This probably a bad idea, since a deploy would potentially change the config. Since this should only happen for local deployments, it isn't too bad though.
2. Make an empty `domain` field a sentinel. During the verification stage, we could inspect the cluster, if available, and extract the domain from there.
