### PR TITLE
don't fail CI matrices fast

### DIFF
--- a/.github/workflows/infracost.yml
+++ b/.github/workflows/infracost.yml
@@ -26,12 +26,12 @@ jobs:
     runs-on: ubuntu-latest
 
     strategy:
-      fail-fast: true
       matrix:
         provider:
           - aws
           - gcp
           - azure
+      fail-fast: false
 
     env:
       # Specify the path where the Terraform state will be stored

--- a/.github/workflows/test-provider.yaml
+++ b/.github/workflows/test-provider.yaml
@@ -51,6 +51,7 @@ jobs:
           - none
           - github-actions
           - gitlab-ci
+        fail-fast: false
     steps:
       - name: "Checkout Infrastructure"
         uses: actions/checkout@v3

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -37,6 +37,7 @@ jobs:
           - "3.9"
           - "3.10"
           - "3.11"
+        fail-fast: false
     steps:
       - name: "Checkout Infrastructure"
         uses: actions/checkout@v3


### PR DESCRIPTION
## Reference Issues or PRs

It is really annoying to see a large matrix completely cancelled just because one job failed. For example: https://github.com/nebari-dev/nebari/actions/runs/4981394220/jobs/8915592409. This is especially true, if the individual parameters aren't strongly correlated. For example, if tests fail on Python 3.8 it is likely that they also fail on 3.9. In contrast, if the provider test fails on AWS, this gives very little insight if the same would also fail on GCP or the like.

Thus, unless we have very strict budget concerns here, it would improve DevX quite a bit to not fail the matrix builds fast. The infracost CI has `fail-fast: true` set, but there is no comment in the PR that added it (#1316) as for why.

## What does this implement/fix?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds a feature)
- [ ] Breaking change (fix or feature that would cause existing features not to work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Other (please describe):
