### PR TITLE
Spinup spot instance for CI with cirun

### DIFF
--- a/.cirun.yml
+++ b/.cirun.yml
@@ -11,6 +11,8 @@ runners:
     # Region: Oregon
     region: us-west-2
     # Use Spot Instances for cost savings
-    preemptible: false
+    preemptible:
+      - true
+      - false
     labels:
       - cirun-runner

--- a/.github/workflows/kubernetes_test.yaml
+++ b/.github/workflows/kubernetes_test.yaml
@@ -11,6 +11,7 @@ on:
       - "src/**"
       - "pyproject.toml"
       - "pytest.ini"
+      - ".cirun.yml"
   push:
     branches:
       - main
@@ -25,6 +26,7 @@ on:
       - "src/**"
       - "pyproject.toml"
       - "pytest.ini"
+      - ".cirun.yml"
   workflow_call:
     inputs:
       pr_number:


### PR DESCRIPTION
This would first try to spinup spot instance and if that fails then will spinup on-demand instance.

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://nebari.dev/community
-->

To save CI costs this would first try to spinup spot instance first and if that fails then will spinup on-demand instance.
See https://docs.cirun.io/reference/fallback-runners#example-3-preemptiblenon-preemptible-instances

## Reference Issues or PRs

<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create a link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

## What does this implement/fix?

_Put a `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds a feature)
- [ ] Breaking change (fix or feature that would cause existing features not to work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [x] Build related changes
- [ ] Other (please describe):

## Testing

- [ ] Did you test the pull request locally?
- [ ] Did you add new tests?

## Any other comments?

<!--
Please be aware that we are a loose team of volunteers, so patience is necessary;
assistance handling other issues is very welcome.
We value all user contributions. If we are slow to review, either the pull request needs some benchmarking, tinkering,
convincing, etc., or the reviewers are likely busy. In either case,
we ask for your understanding during the
review process.
Thanks for contributing to Nebari 🙏🏼!
-->
