### PR TITLE
Ensure path is Path object

### DIFF
--- a/src/_nebari/initialize.py
+++ b/src/_nebari/initialize.py
@@ -549,9 +549,9 @@ def github_auto_provision(config, owner, repo):
 
 
 def git_repository_initialize(git_repository):
-    if not git.is_git_repo("./"):
-        git.initialize_git("./")
-    git.add_git_remote(git_repository, path="./", remote_name="origin")
+    if not git.is_git_repo(Path.cwd()):
+        git.initialize_git(Path.cwd())
+    git.add_git_remote(git_repository, path=Path.cwd(), remote_name="origin")
 
 
 def auth0_auto_provision(config):

--- a/src/_nebari/provider/git.py
+++ b/src/_nebari/provider/git.py
@@ -7,11 +7,15 @@ from _nebari.utils import change_directory
 
 
 def is_git_repo(path=None):
+    if isinstance(path, str):
+        path = Path(path)
     path = path or Path.cwd()
     return ".git" in os.listdir(path)
 
 
 def initialize_git(path=None):
+    if isinstance(path, str):
+        path = Path(path)
     path = path or Path.cwd()
     with change_directory(path):
         subprocess.check_output(["git", "init"])
@@ -20,6 +24,8 @@ def initialize_git(path=None):
 
 
 def add_git_remote(remote_path, path=None, remote_name="origin"):
+    if isinstance(path, str):
+        path = Path(path)
     path = path or Path.cwd()
 
     c = configparser.ConfigParser()

--- a/src/_nebari/provider/git.py
+++ b/src/_nebari/provider/git.py
@@ -6,16 +6,12 @@ from pathlib import Path
 from _nebari.utils import change_directory
 
 
-def is_git_repo(path=None):
-    if isinstance(path, str):
-        path = Path(path)
+def is_git_repo(path: Path = None):
     path = path or Path.cwd()
     return ".git" in os.listdir(path)
 
 
-def initialize_git(path=None):
-    if isinstance(path, str):
-        path = Path(path)
+def initialize_git(path: Path = None):
     path = path or Path.cwd()
     with change_directory(path):
         subprocess.check_output(["git", "init"])
@@ -23,9 +19,7 @@ def initialize_git(path=None):
         subprocess.check_output(["git", "checkout", "-b", "main"])
 
 
-def add_git_remote(remote_path, path=None, remote_name="origin"):
-    if isinstance(path, str):
-        path = Path(path)
+def add_git_remote(remote_path: str, path: Path = None, remote_name: str = "origin"):
     path = path or Path.cwd()
 
     c = configparser.ConfigParser()


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://nebari.dev/community
-->

## Reference Issues or PRs

<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create a link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

Bug fix: the `path` object is assumed to be a `pathlib.Path` object. This fix ensure that this is indeed the case.

## What does this implement/fix?

_Put a `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds a feature)
- [ ] Breaking change (fix or feature that would cause existing features not to work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Other (please describe):

## Testing

- [ ] Did you test the pull request locally?
- [ ] Did you add new tests?

## Any other comments?

<!--
Please be aware that we are a loose team of volunteers, so patience is necessary;
assistance handling other issues is very welcome.
We value all user contributions. If we are slow to review, either the pull request needs some benchmarking, tinkering,
convincing, etc., or the reviewers are likely busy. In either case,
we ask for your understanding during the
review process.
Thanks for contributing to Nebari 🙏🏼!
-->
