### PR TITLE
Bump DigitalOcean provider to latest

### DIFF
--- a/src/_nebari/template/stages/01-terraform-state/do/main.tf
+++ b/src/_nebari/template/stages/01-terraform-state/do/main.tf
@@ -28,7 +28,7 @@ terraform {
   required_providers {
     digitalocean = {
       source  = "digitalocean/digitalocean"
-      version = "2.17.0"
+      version = "2.29.0"
     }
   }
   required_version = ">= 1.0"

--- a/src/_nebari/template/stages/01-terraform-state/do/modules/spaces/versions.tf
+++ b/src/_nebari/template/stages/01-terraform-state/do/modules/spaces/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     digitalocean = {
       source  = "digitalocean/digitalocean"
-      version = "2.17.0"
+      version = "2.29.0"
     }
   }
   required_version = ">= 1.0"

--- a/src/_nebari/template/stages/01-terraform-state/do/modules/terraform-state/versions.tf
+++ b/src/_nebari/template/stages/01-terraform-state/do/modules/terraform-state/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     digitalocean = {
       source  = "digitalocean/digitalocean"
-      version = "2.17.0"
+      version = "2.29.0"
     }
   }
   required_version = ">= 1.0"

--- a/src/_nebari/template/stages/02-infrastructure/do/modules/kubernetes/versions.tf
+++ b/src/_nebari/template/stages/02-infrastructure/do/modules/kubernetes/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     digitalocean = {
       source  = "digitalocean/digitalocean"
-      version = "2.17.0"
+      version = "2.29.0"
     }
   }
   required_version = ">= 1.0"

--- a/src/_nebari/template/stages/02-infrastructure/do/modules/registry/versions.tf
+++ b/src/_nebari/template/stages/02-infrastructure/do/modules/registry/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     digitalocean = {
       source  = "digitalocean/digitalocean"
-      version = "2.17.0"
+      version = "2.29.0"
     }
   }
   required_version = ">= 1.0"


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://nebari.dev/community
-->

## Reference Issues or PRs

The current provider was causing 404 (bucket not found error) too often, even though the bucket was present.
Ideally we should have this version only at one place, but not doing that change in this PR, to avoid too much conflict for Extension mechanism PR.

This has been tested here: https://github.com/nebari-dev/nebari/actions/runs/5756197370/job/15605162909

<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create a link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

## What does this implement/fix?

_Put a `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds a feature)
- [ ] Breaking change (fix or feature that would cause existing features not to work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Other (please describe):

## Testing

- [ ] Did you test the pull request locally?
- [ ] Did you add new tests?

## Any other comments?

<!--
Please be aware that we are a loose team of volunteers, so patience is necessary;
assistance handling other issues is very welcome.
We value all user contributions. If we are slow to review, either the pull request needs some benchmarking, tinkering,
convincing, etc., or the reviewers are likely busy. In either case,
we ask for your understanding during the
review process.
Thanks for contributing to Nebari 🙏🏼!
-->
