### PR TITLE
Allow users to specify the Azure RG to deploy into

### DIFF
--- a/src/_nebari/stages/infrastructure/__init__.py
+++ b/src/_nebari/stages/infrastructure/__init__.py
@@ -22,9 +22,9 @@ from _nebari.stages.base import NebariTerraformStage
 from _nebari.stages.tf_objects import NebariTerraformState
 from _nebari.utils import (
     AZURE_NODE_RESOURCE_GROUP_SUFFIX,
+    construct_azure_resource_group_name,
     modified_environ,
     random_secure_string,
-    set_azure_resource_group_name,
 )
 from nebari import schema
 from nebari.hookspecs import NebariStage, hookimpl
@@ -706,15 +706,15 @@ class KubernetesInfrastructureStage(NebariTerraformStage):
                     )
                     for name, node_group in self.config.azure.node_groups.items()
                 },
-                resource_group_name=set_azure_resource_group_name(
+                resource_group_name=construct_azure_resource_group_name(
                     project_name=self.config.project_name,
                     namespace=self.config.namespace,
-                    resource_group_name=self.config.azure.resource_group_name,
+                    base_resource_group_name=self.config.azure.resource_group_name,
                 ),
-                node_resource_group_name=set_azure_resource_group_name(
+                node_resource_group_name=construct_azure_resource_group_name(
                     project_name=self.config.project_name,
                     namespace=self.config.namespace,
-                    resource_group_name=self.config.azure.resource_group_name,
+                    base_resource_group_name=self.config.azure.resource_group_name,
                     suffix=AZURE_NODE_RESOURCE_GROUP_SUFFIX,
                 ),
                 vnet_subnet_id=self.config.azure.vnet_subnet_id,

--- a/src/_nebari/stages/infrastructure/__init__.py
+++ b/src/_nebari/stages/infrastructure/__init__.py
@@ -21,14 +21,13 @@ from _nebari.provider.cloud import (
 from _nebari.stages.base import NebariTerraformStage
 from _nebari.stages.tf_objects import NebariTerraformState
 from _nebari.utils import (
+    AZURE_NODE_RESOURCE_GROUP_SUFFIX,
     modified_environ,
     random_secure_string,
     set_azure_resource_group_name,
 )
 from nebari import schema
 from nebari.hookspecs import NebariStage, hookimpl
-
-AZURE_NODE_RESOURCE_GROUP_SUFFIX = "-node-resource-group"
 
 
 def get_kubeconfig_filename():
@@ -366,7 +365,6 @@ class AzureNodeGroup(schema.Base):
 
 
 class AzureProvider(schema.Base):
-    # TODO: add validation for resource_group_name
     resource_group_name: str = None
     region: str = "Central US"
     kubernetes_version: typing.Optional[str]
@@ -707,12 +705,12 @@ class KubernetesInfrastructureStage(NebariTerraformStage):
                     for name, node_group in self.config.azure.node_groups.items()
                 },
                 resource_group_name=set_azure_resource_group_name(
-                    project_name=self.config.name,
+                    project_name=self.config.project_name,
                     namespace=self.config.namespace,
                     resource_group_name=self.config.azure.resource_group_name,
                 ),
                 node_resource_group_name=set_azure_resource_group_name(
-                    project_name=self.config.name,
+                    project_name=self.config.project_name,
                     namespace=self.config.namespace,
                     resource_group_name=self.config.azure.resource_group_name,
                     suffix=AZURE_NODE_RESOURCE_GROUP_SUFFIX,

--- a/src/_nebari/stages/infrastructure/__init__.py
+++ b/src/_nebari/stages/infrastructure/__init__.py
@@ -394,6 +394,8 @@ class AzureProvider(schema.Base):
 
     @pydantic.validator("resource_group_name")
     def _validate_resource_group_name(cls, value):
+        if value is None:
+            return value
         length = len(value) + len(AZURE_NODE_RESOURCE_GROUP_SUFFIX)
         if length < 1 or length > 90:
             raise ValueError(

--- a/src/_nebari/stages/infrastructure/__init__.py
+++ b/src/_nebari/stages/infrastructure/__init__.py
@@ -406,7 +406,7 @@ class AzureProvider(schema.Base):
                 "Azure Resource Group name can only contain alphanumerics, underscores, parentheses, hyphens, and periods."
             )
         if value[-1] == ".":
-            raise ValueError("Resource Group name can't end with a period.")
+            raise ValueError("Azure Resource Group name can't end with a period.")
 
         return value
 

--- a/src/_nebari/stages/infrastructure/__init__.py
+++ b/src/_nebari/stages/infrastructure/__init__.py
@@ -395,15 +395,15 @@ class AzureProvider(schema.Base):
         return value
 
     @pydantic.validator("resource_group_name")
-    def validate_name(cls, value):
+    def _validate_resource_group_name(cls, value):
         length = len(value) + len(AZURE_NODE_RESOURCE_GROUP_SUFFIX)
         if length < 1 or length > 90:
             raise ValueError(
-                f"Resource Group name must be between 1 and 90 characters long, when combined with the suffix `{AZURE_NODE_RESOURCE_GROUP_SUFFIX}`."
+                f"Azure Resource Group name must be between 1 and 90 characters long, when combined with the suffix `{AZURE_NODE_RESOURCE_GROUP_SUFFIX}`."
             )
         if not re.match(r"^[\w\-\.\(\)]+$", value):
             raise ValueError(
-                "Resource Group name can only contain alphanumerics, underscores, parentheses, hyphens, and periods."
+                "Azure Resource Group name can only contain alphanumerics, underscores, parentheses, hyphens, and periods."
             )
         if value[-1] == ".":
             raise ValueError("Resource Group name can't end with a period.")

--- a/src/_nebari/stages/terraform_state/__init__.py
+++ b/src/_nebari/stages/terraform_state/__init__.py
@@ -40,6 +40,8 @@ class AzureInputVars(schema.Base):
 
     @pydantic.validator("state_resource_group_name")
     def _validate_resource_group_name(cls, value):
+        if value is None:
+            return value
         length = len(value) + len(AZURE_TF_STATE_RESOURCE_GROUP_SUFFIX)
         if length < 1 or length > 90:
             raise ValueError(

--- a/src/_nebari/stages/terraform_state/__init__.py
+++ b/src/_nebari/stages/terraform_state/__init__.py
@@ -10,11 +10,13 @@ from typing import Any, Dict, List, Tuple
 import pydantic
 
 from _nebari.stages.base import NebariTerraformStage
-from _nebari.utils import modified_environ, set_azure_resource_group_name
+from _nebari.utils import (
+    AZURE_TF_STATE_RESOURCE_GROUP_SUFFIX,
+    modified_environ,
+    set_azure_resource_group_name,
+)
 from nebari import schema
 from nebari.hookspecs import NebariStage, hookimpl
-
-AZURE_TF_STATE_RESOURCE_GROUP_SUFFIX = "-state"
 
 
 class DigitalOceanInputVars(schema.Base):
@@ -121,7 +123,7 @@ class TerraformStateStage(NebariTerraformStage):
             subscription_id = os.environ["ARM_SUBSCRIPTION_ID"]
             resource_name_prefix = f"{self.config.project_name}-{self.config.namespace}"
             state_resource_group_name = set_azure_resource_group_name(
-                project_name=self.config.name,
+                project_name=self.config.project_name,
                 namespace=self.config.namespace,
                 resource_group_name=self.config.azure.resource_group_name,
                 suffix=AZURE_TF_STATE_RESOURCE_GROUP_SUFFIX,
@@ -184,7 +186,12 @@ class TerraformStateStage(NebariTerraformStage):
                 namespace=self.config.namespace,
                 region=self.config.azure.region,
                 storage_account_postfix=self.config.azure.storage_account_postfix,
-                state_resource_group_name=f"{self.config.project_name}-{self.config.namespace}-state",
+                state_resource_group_name=set_azure_resource_group_name(
+                    project_name=self.config.project_name,
+                    namespace=self.config.namespace,
+                    resource_group_name=self.config.azure.resource_group_name,
+                    suffix=AZURE_TF_STATE_RESOURCE_GROUP_SUFFIX,
+                ),
             ).dict()
         elif (
             self.config.provider == schema.ProviderEnum.local

--- a/src/_nebari/stages/terraform_state/__init__.py
+++ b/src/_nebari/stages/terraform_state/__init__.py
@@ -48,7 +48,7 @@ class AzureInputVars(schema.Base):
                 "Azure Resource Group name can only contain alphanumerics, underscores, parentheses, hyphens, and periods."
             )
         if value[-1] == ".":
-            raise ValueError("Resource Group name can't end with a period.")
+            raise ValueError("Azure Resource Group name can't end with a period.")
 
         return value
 

--- a/src/_nebari/stages/terraform_state/__init__.py
+++ b/src/_nebari/stages/terraform_state/__init__.py
@@ -37,15 +37,15 @@ class AzureInputVars(schema.Base):
     state_resource_group_name: str
 
     @pydantic.validator("state_resource_group_name")
-    def validate_name(cls, value):
+    def _validate_resource_group_name(cls, value):
         length = len(value) + len(AZURE_TF_STATE_RESOURCE_GROUP_SUFFIX)
         if length < 1 or length > 90:
             raise ValueError(
-                f"Resource Group name must be between 1 and 90 characters long, when combined with the suffix `{AZURE_TF_STATE_RESOURCE_GROUP_SUFFIX}`."
+                f"Azure Resource Group name must be between 1 and 90 characters long, when combined with the suffix `{AZURE_TF_STATE_RESOURCE_GROUP_SUFFIX}`."
             )
         if not re.match(r"^[\w\-\.\(\)]+$", value):
             raise ValueError(
-                "Resource Group name can only contain alphanumerics, underscores, parentheses, hyphens, and periods."
+                "Azure Resource Group name can only contain alphanumerics, underscores, parentheses, hyphens, and periods."
             )
         if value[-1] == ".":
             raise ValueError("Resource Group name can't end with a period.")

--- a/src/_nebari/stages/terraform_state/__init__.py
+++ b/src/_nebari/stages/terraform_state/__init__.py
@@ -7,7 +7,7 @@ import typing
 from typing import Any, Dict, List, Tuple
 
 from _nebari.stages.base import NebariTerraformStage
-from _nebari.utils import modified_environ
+from _nebari.utils import modified_environ, set_azure_resource_group_name
 from nebari import schema
 from nebari.hookspecs import NebariStage, hookimpl
 
@@ -99,7 +99,12 @@ class TerraformStateStage(NebariTerraformStage):
         elif self.config.provider == schema.ProviderEnum.azure:
             subscription_id = os.environ["ARM_SUBSCRIPTION_ID"]
             resource_name_prefix = f"{self.config.project_name}-{self.config.namespace}"
-            state_resource_group_name = f"{resource_name_prefix}-state"
+            state_resource_group_name = (
+                self.config.azure.resource_group_name
+                or set_azure_resource_group_name(
+                    self.config.name, self.config.namespace, suffix="-state"
+                )
+            )
             state_resource_name_prefix_safe = resource_name_prefix.replace("-", "")
             resource_group_url = f"/subscriptions/{subscription_id}/resourceGroups/{state_resource_group_name}"
 

--- a/src/_nebari/stages/terraform_state/__init__.py
+++ b/src/_nebari/stages/terraform_state/__init__.py
@@ -12,8 +12,8 @@ import pydantic
 from _nebari.stages.base import NebariTerraformStage
 from _nebari.utils import (
     AZURE_TF_STATE_RESOURCE_GROUP_SUFFIX,
+    construct_azure_resource_group_name,
     modified_environ,
-    set_azure_resource_group_name,
 )
 from nebari import schema
 from nebari.hookspecs import NebariStage, hookimpl
@@ -124,10 +124,10 @@ class TerraformStateStage(NebariTerraformStage):
         elif self.config.provider == schema.ProviderEnum.azure:
             subscription_id = os.environ["ARM_SUBSCRIPTION_ID"]
             resource_name_prefix = f"{self.config.project_name}-{self.config.namespace}"
-            state_resource_group_name = set_azure_resource_group_name(
+            state_resource_group_name = construct_azure_resource_group_name(
                 project_name=self.config.project_name,
                 namespace=self.config.namespace,
-                resource_group_name=self.config.azure.resource_group_name,
+                base_resource_group_name=self.config.azure.resource_group_name,
                 suffix=AZURE_TF_STATE_RESOURCE_GROUP_SUFFIX,
             )
             state_resource_name_prefix_safe = resource_name_prefix.replace("-", "")
@@ -188,10 +188,10 @@ class TerraformStateStage(NebariTerraformStage):
                 namespace=self.config.namespace,
                 region=self.config.azure.region,
                 storage_account_postfix=self.config.azure.storage_account_postfix,
-                state_resource_group_name=set_azure_resource_group_name(
+                state_resource_group_name=construct_azure_resource_group_name(
                     project_name=self.config.project_name,
                     namespace=self.config.namespace,
-                    resource_group_name=self.config.azure.resource_group_name,
+                    base_resource_group_name=self.config.azure.resource_group_name,
                     suffix=AZURE_TF_STATE_RESOURCE_GROUP_SUFFIX,
                 ),
             ).dict()

--- a/src/_nebari/stages/tf_objects.py
+++ b/src/_nebari/stages/tf_objects.py
@@ -1,5 +1,9 @@
 from _nebari.provider.terraform import Data, Provider, TerraformBackend
-from _nebari.utils import deep_merge
+from _nebari.utils import (
+    AZURE_TF_STATE_RESOURCE_GROUP_SUFFIX,
+    deep_merge,
+    set_azure_resource_group_name,
+)
 from nebari import schema
 
 
@@ -80,7 +84,12 @@ def NebariTerraformState(directory: str, nebari_config: schema.Main):
     elif nebari_config.provider == "azure":
         return TerraformBackend(
             "azurerm",
-            resource_group_name=f"{nebari_config.escaped_project_name}-{nebari_config.namespace}-state",
+            resource_group_name=set_azure_resource_group_name(
+                project_name=nebari_config.project_name,
+                namespace=nebari_config.namespace,
+                resource_group_name=nebari_config.azure.resource_group_name,
+                suffix=AZURE_TF_STATE_RESOURCE_GROUP_SUFFIX,
+            ),
             # storage account must be globally unique
             storage_account_name=f"{nebari_config.escaped_project_name}{nebari_config.namespace}{nebari_config.azure.storage_account_postfix}",
             container_name=f"{nebari_config.escaped_project_name}-{nebari_config.namespace}-state",

--- a/src/_nebari/stages/tf_objects.py
+++ b/src/_nebari/stages/tf_objects.py
@@ -1,8 +1,8 @@
 from _nebari.provider.terraform import Data, Provider, TerraformBackend
 from _nebari.utils import (
     AZURE_TF_STATE_RESOURCE_GROUP_SUFFIX,
+    construct_azure_resource_group_name,
     deep_merge,
-    set_azure_resource_group_name,
 )
 from nebari import schema
 
@@ -84,10 +84,10 @@ def NebariTerraformState(directory: str, nebari_config: schema.Main):
     elif nebari_config.provider == "azure":
         return TerraformBackend(
             "azurerm",
-            resource_group_name=set_azure_resource_group_name(
+            resource_group_name=construct_azure_resource_group_name(
                 project_name=nebari_config.project_name,
                 namespace=nebari_config.namespace,
-                resource_group_name=nebari_config.azure.resource_group_name,
+                base_resource_group_name=nebari_config.azure.resource_group_name,
                 suffix=AZURE_TF_STATE_RESOURCE_GROUP_SUFFIX,
             ),
             # storage account must be globally unique

--- a/src/_nebari/utils.py
+++ b/src/_nebari/utils.py
@@ -280,3 +280,9 @@ def is_relative_to(self: Path, other: Path, /) -> bool:
 def set_do_environment():
     os.environ["AWS_ACCESS_KEY_ID"] = os.environ["SPACES_ACCESS_KEY_ID"]
     os.environ["AWS_SECRET_ACCESS_KEY"] = os.environ["SPACES_SECRET_ACCESS_KEY"]
+
+
+def set_azure_resource_group_name(
+    project_name: str, namespace: str, suffix: str = ""
+) -> str:
+    return f"{project_name}-{namespace}{suffix}"

--- a/src/_nebari/utils.py
+++ b/src/_nebari/utils.py
@@ -283,12 +283,18 @@ def set_do_environment():
     os.environ["AWS_SECRET_ACCESS_KEY"] = os.environ["SPACES_SECRET_ACCESS_KEY"]
 
 
-def set_azure_resource_group_name(
+def construct_azure_resource_group_name(
     project_name: str = "",
     namespace: str = "",
-    resource_group_name: str = "",
+    base_resource_group_name: str = "",
     suffix: str = "",
 ) -> str:
-    if resource_group_name:
-        return f"{resource_group_name}{suffix}"
+    """
+    Construct a resource group name for Azure.
+
+    If the base_resource_group_name is provided, it will be used as the base,
+    otherwise default to the project_name-namespace.
+    """
+    if base_resource_group_name:
+        return f"{base_resource_group_name}{suffix}"
     return f"{project_name}-{namespace}{suffix}"

--- a/src/_nebari/utils.py
+++ b/src/_nebari/utils.py
@@ -18,7 +18,8 @@ from ruamel.yaml import YAML
 # environment variable overrides
 NEBARI_GH_BRANCH = os.getenv("NEBARI_GH_BRANCH", None)
 
-CONDA_FORGE_CHANNEL_DATA_URL = "https://conda.anaconda.org/conda-forge/channeldata.json"
+AZURE_TF_STATE_RESOURCE_GROUP_SUFFIX = "-state"
+AZURE_NODE_RESOURCE_GROUP_SUFFIX = "-node-resource-group"
 
 # Create a ruamel object with our favored config, for universal use
 yaml = YAML()

--- a/src/_nebari/utils.py
+++ b/src/_nebari/utils.py
@@ -283,6 +283,11 @@ def set_do_environment():
 
 
 def set_azure_resource_group_name(
-    project_name: str, namespace: str, suffix: str = ""
+    project_name: str = "",
+    namespace: str = "",
+    resource_group_name: str = "",
+    suffix: str = "",
 ) -> str:
+    if resource_group_name:
+        return f"{resource_group_name}{suffix}"
     return f"{project_name}-{namespace}{suffix}"


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://nebari.dev/community
-->

## Reference Issues or PRs

<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create a link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

Allow users to specify (via the nebari-config.yaml) which Azure Resource Group they deploy into. This also tries to preserve backward-compatibility so if nothing is provided, the default (current) behavior will be the same.

## What does this implement/fix?

_Put a `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds a feature)
- [ ] Breaking change (fix or feature that would cause existing features not to work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Other (please describe):

## Testing

- [ ] Did you test the pull request locally?
- [ ] Did you add new tests?

## Any other comments?

<!--
Please be aware that we are a loose team of volunteers, so patience is necessary;
assistance handling other issues is very welcome.
We value all user contributions. If we are slow to review, either the pull request needs some benchmarking, tinkering,
convincing, etc., or the reviewers are likely busy. In either case,
we ask for your understanding during the
review process.
Thanks for contributing to Nebari 🙏🏼!
-->
