### PR TITLE
Modify JupyterHub networkPolicy to match existing policy

### DIFF
--- a/src/_nebari/stages/kubernetes_services/template/modules/kubernetes/services/jupyterhub/values.yaml
+++ b/src/_nebari/stages/kubernetes_services/template/modules/kubernetes/services/jupyterhub/values.yaml
@@ -14,7 +14,21 @@ proxy:
     type: ClusterIP
   chp:
     networkPolicy:
-      enabled: false
+      egressAllowRules:
+        cloudMetadataServer: false
+        dnsPortsPrivateIPs: false
+        nonPrivateIPs: false
+        privateIPs: false
+
+      egress:
+        - ports:
+          - port: 53
+            protocol: UDP
+          - port: 53
+            protocol: TCP
+        - to:
+          - ipBlock:
+              cidr: 0.0.0.0/0
 
 scheduling:
   userScheduler:

--- a/src/_nebari/stages/kubernetes_services/template/modules/kubernetes/services/jupyterhub/values.yaml
+++ b/src/_nebari/stages/kubernetes_services/template/modules/kubernetes/services/jupyterhub/values.yaml
@@ -12,6 +12,9 @@ proxy:
   secretToken: "<placeholder>"
   service:
     type: ClusterIP
+  chp:
+    networkPolicy:
+      enabled: false
 
 scheduling:
   userScheduler:


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://nebari.dev/community
-->

## Reference Issues or PRs

<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create a link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

## What does this implement/fix?

Fixes #1965 

Having the CHP networkPolicy enabled for JupyterHub deployed to AWS, Azure and GCP was no trouble so I'm not sure why this only seems to affect Digital Ocean. We also have the networkPolicy disabled for `hub` and `singleuser` already. 

We should definitely test this change on the other clouds before merging - I don't expect this to cause problems since removing the network policy makes internal networking more permissible.


_Put a `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds a feature)
- [ ] Breaking change (fix or feature that would cause existing features not to work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Other (please describe):

## Testing

- [x] Did you test the pull request locally?
- [ ] Did you add new tests?

## Any other comments?

<!--
Please be aware that we are a loose team of volunteers, so patience is necessary;
assistance handling other issues is very welcome.
We value all user contributions. If we are slow to review, either the pull request needs some benchmarking, tinkering,
convincing, etc., or the reviewers are likely busy. In either case,
we ask for your understanding during the
review process.
Thanks for contributing to Nebari 🙏🏼!
-->
