### PR TITLE
remove custom auth from config schema

### DIFF
--- a/src/_nebari/stages/kubernetes_keycloak/__init__.py
+++ b/src/_nebari/stages/kubernetes_keycloak/__init__.py
@@ -54,7 +54,6 @@ class AuthenticationEnum(str, enum.Enum):
     password = "password"
     github = "GitHub"
     auth0 = "Auth0"
-    custom = "custom"
 
     @classmethod
     def to_yaml(cls, representer, node):

--- a/src/_nebari/upgrade.py
+++ b/src/_nebari/upgrade.py
@@ -286,6 +286,8 @@ class Upgrade_0_3_12(UpgradeStep):
             rich.print(
                 f"Adding default_images: conda_store image as [green]{newimage}[/green]"
             )
+            if "default_images" not in config:
+                config["default_images"] = {}
             config["default_images"]["conda_store"] = newimage
         return config
 
@@ -377,6 +379,9 @@ class Upgrade_0_4_0(UpgradeStep):
             rich.print(
                 "Removing terraform_modules field from config as it is no longer used.\n"
             )
+
+        if "default_images" not in config:
+            config["default_images"] = {}
 
         # Remove conda_store image from default_images
         if "conda_store" in config["default_images"]:

--- a/tests/tests_unit/cli_validate/local.error.authentication-type-called-custom.yaml
+++ b/tests/tests_unit/cli_validate/local.error.authentication-type-called-custom.yaml
@@ -1,0 +1,5 @@
+project_name: test
+security:
+  authentication:
+    type: custom
+    

--- a/tests/tests_unit/cli_validate/local.error.authentication-type-called-custom.yaml
+++ b/tests/tests_unit/cli_validate/local.error.authentication-type-called-custom.yaml
@@ -2,4 +2,3 @@ project_name: test
 security:
   authentication:
     type: custom
-    

--- a/tests/tests_unit/test_cli_init.py
+++ b/tests/tests_unit/test_cli_init.py
@@ -61,7 +61,7 @@ def generate_test_data_test_cli_init_happy_path():
                 for namespace in ["test-ns"]:
                     for auth_provider in [
                         "password"
-                    ]:  # ["password", "Auth0", "GitHub", "custom"] # Auth0, Github and custom failing as of 2023-08-23
+                    ]:  # ["password", "Auth0", "GitHub"] # Auth0, Github failing as of 2023-08-23
                         for repository in ["github.com", "gitlab.com"]:
                             for ci_provider in ["none", "github-actions", "gitlab-ci"]:
                                 for terraform_state in ["local", "remote", "existing"]:


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://nebari.dev/community
-->

Fixes #1934 

Removes the `custom` auth provider option from the config schema. Includes unit tests to cover the upgrade path that was intended to handle the removal of this previously.

<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create a link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

## What does this implement/fix?

_Put a `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds a feature)
- [ ] Breaking change (fix or feature that would cause existing features not to work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Other (please describe):

## Testing

- [x] Did you test the pull request locally?
- [x] Did you add new tests?

## Any other comments?

<!--
Please be aware that we are a loose team of volunteers, so patience is necessary;
assistance handling other issues is very welcome.
We value all user contributions. If we are slow to review, either the pull request needs some benchmarking, tinkering,
convincing, etc., or the reviewers are likely busy. In either case,
we ask for your understanding during the
review process.
Thanks for contributing to Nebari 🙏🏼!
-->
