### PR TITLE
Add permissions to generate_cli_docs workflow

### DIFF
--- a/.github/workflows/generate_cli_doc.yml
+++ b/.github/workflows/generate_cli_doc.yml
@@ -2,6 +2,8 @@ name: Update API docs
 
 on:
   pull_request:
+    paths:
+    - "src/_nebari/subcommands/**"
   push:
     branches:
       - main
@@ -49,7 +51,7 @@ jobs:
       - name: Create Pull Request in code repo
         id: create_pull_request
         uses: peter-evans/create-pull-request@v4
-        if: steps.verify-changed-files.outputs.files_changed == 'true'
+        if: steps.verify-changed-files.outputs.files_changed == 'true' && github.event_name != 'pull_request'
         with:
           token: ${{ secrets.NEBARI_SENSEI_API_DOCS_PR_OPENER }}
           commit-message: Update api docs

--- a/.github/workflows/generate_cli_doc.yml
+++ b/.github/workflows/generate_cli_doc.yml
@@ -9,6 +9,9 @@ on:
 
 jobs:
   update_api:
+    permissions:
+      contents: write
+      pull-requests: write
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/.github/workflows/generate_cli_doc.yml
+++ b/.github/workflows/generate_cli_doc.yml
@@ -4,9 +4,13 @@ on:
   pull_request:
     paths:
     - "src/_nebari/subcommands/**"
+    - "src/_nebari/cli.py"
   push:
     branches:
       - main
+    paths:
+    - "src/_nebari/subcommands/**"
+    - "src/_nebari/cli.py"
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://nebari.dev/community
-->

## Reference Issues or PRs

The API docs PR introduced a workflow to check for changes to the CLI, and if changes exist, that workflow will open a PR against the nebari-docs repo. This PR simply gives the workflow the required permissions to create this PR.

<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create a link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

## What does this implement/fix?

_Put a `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds a feature)
- [ ] Breaking change (fix or feature that would cause existing features not to work as expected)
- [x] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Other (please describe):

## Testing

- [ ] Did you test the pull request locally?
- [ ] Did you add new tests?

## Any other comments?

<!--
Please be aware that we are a loose team of volunteers, so patience is necessary;
assistance handling other issues is very welcome.
We value all user contributions. If we are slow to review, either the pull request needs some benchmarking, tinkering,
convincing, etc., or the reviewers are likely busy. In either case,
we ask for your understanding during the
review process.
Thanks for contributing to Nebari 🙏🏼!
-->
