### PR TITLE
Block usage of pip inside jupyterlab 

### DIFF
--- a/src/_nebari/stages/kubernetes_services/template/modules/kubernetes/services/jupyterhub/files/jupyterhub/03-profiles.py
+++ b/src/_nebari/stages/kubernetes_services/template/modules/kubernetes/services/jupyterhub/files/jupyterhub/03-profiles.py
@@ -245,6 +245,8 @@ def configure_user(username, groups, uid=1000, gid=100):
         "SHELL": "/bin/bash",
         # set home directory to username
         "HOME": f"/home/{username}",
+        # Disable global usage of pip
+        "PIP_REQUIRE_VIRTUALENV": "true",
     }
 
     etc_passwd, etc_group = generate_nss_files(


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://nebari.dev/community
-->

## Reference Issues or PRs

<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create a link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

closes #2133 

## What does this implement/fix?

This update adds a blocking configuration (globally applied) to the pip command, where its usage will only be habilitated if the user uses a ` virtualenv,` which we can assume the user will not attempt as we already provide the conda environments for such needs.

As an environment variable controls this, it's still possible to be overridden by the user if the variable's value is modified.

_Put a `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds a feature)
- [ ] Breaking change (fix or feature that would cause existing features not to work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Other (please describe):

## Testing

- [x] Did you test the pull request locally?
- [ ] Did you add new tests?

## Any other comments?
Tested within a local deployment:

- from within a notebook:
![image](https://github.com/nebari-dev/nebari/assets/51954708/59b9fc1d-dcd1-4c85-888d-edd7f13562ad)
- from terminal:
![image](https://github.com/nebari-dev/nebari/assets/51954708/19c058c3-bb75-4286-a52f-76cfdca53f7f)

obs.: tested within all envs to make sure it was supplied as a global update

<!--
Please be aware that we are a loose team of volunteers, so patience is necessary;
assistance handling other issues is very welcome.
We value all user contributions. If we are slow to review, either the pull request needs some benchmarking, tinkering,
convincing, etc., or the reviewers are likely busy. In either case,
we ask for your understanding during the
review process.
Thanks for contributing to Nebari 🙏🏼!
-->
