### PR TITLE
Return all environments instead of just those under the user's namespace for jhub-apps

### DIFF
--- a/src/_nebari/stages/kubernetes_services/template/modules/kubernetes/services/jupyterhub/files/jupyterhub/02-spawner.py
+++ b/src/_nebari/stages/kubernetes_services/template/modules/kubernetes/services/jupyterhub/files/jupyterhub/02-spawner.py
@@ -38,11 +38,7 @@ def get_conda_store_environments(user_info: dict):
     # parse response
     j = json.loads(response.data.decode("UTF-8"))
     # Filter and return conda environments for the user
-    return [
-        f"{env['namespace']['name']}-{env['name']}"
-        for env in j.get("data", [])
-        if env["namespace"]["name"] == user_info.get("name")
-    ]
+    return [f"{env['namespace']['name']}-{env['name']}" for env in j.get("data", [])]
 
 
 c.Spawner.pre_spawn_hook = get_username_hook


### PR DESCRIPTION
For the time being, we'll return all the environments instead of just those under the user's namespace for jhub-apps. In the future, we'd like to expose a way of filtering all the environments a specific user has access to from conda-store.

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://nebari.dev/community
-->

## Reference Issues or PRs

#2193 

<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create a link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

## What does this implement/fix?

_Put a `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds a feature)
- [ ] Breaking change (fix or feature that would cause existing features not to work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Other (please describe):

## Testing

- [ ] Did you test the pull request locally?
- [ ] Did you add new tests?

## Any other comments?

<!--
Please be aware that we are a loose team of volunteers, so patience is necessary;
assistance handling other issues is very welcome.
We value all user contributions. If we are slow to review, either the pull request needs some benchmarking, tinkering,
convincing, etc., or the reviewers are likely busy. In either case,
we ask for your understanding during the
review process.
Thanks for contributing to Nebari 🙏🏼!
-->
