### PR TITLE
Adding a temporary writable directory for conda-store server /home/conda

### DIFF
--- a/src/_nebari/stages/kubernetes_services/template/modules/kubernetes/services/conda-store/server.tf
+++ b/src/_nebari/stages/kubernetes_services/template/modules/kubernetes/services/conda-store/server.tf
@@ -160,7 +160,7 @@ resource "kubernetes_deployment" "server" {
           volume_mount {
             name       = "home-volume"
             mount_path = "/home/conda"
-          }          
+          }
         }
 
         volume {
@@ -182,7 +182,7 @@ resource "kubernetes_deployment" "server" {
           empty_dir {
             size_limit = "1Mi"
           }
-        }        
+        }
       }
     }
   }

--- a/src/_nebari/stages/kubernetes_services/template/modules/kubernetes/services/conda-store/server.tf
+++ b/src/_nebari/stages/kubernetes_services/template/modules/kubernetes/services/conda-store/server.tf
@@ -156,6 +156,11 @@ resource "kubernetes_deployment" "server" {
             name       = "secret"
             mount_path = "/var/lib/conda-store/"
           }
+
+          volume_mount {
+            name       = "home-volume"
+            mount_path = "/home/conda"
+          }          
         }
 
         volume {
@@ -171,6 +176,13 @@ resource "kubernetes_deployment" "server" {
             secret_name = kubernetes_secret.conda-store-secret.metadata.0.name
           }
         }
+
+        volume {
+          name = "home-volume"
+          empty_dir {
+            size_limit = "1Mi"
+          }
+        }        
       }
     }
   }


### PR DESCRIPTION
Closes #2186

I have tested this forward upgrade from an older conda-store image. Love the new UI upgrade! 

This change is required from https://github.com/conda-incubator/conda-store/pull/639 and we are just creating the directory ahead of time which the server tries to create (it is not actually used by the server)