### PR TITLE
Make it so that jhub-apps default theme doesn't override

### DIFF
--- a/src/_nebari/stages/kubernetes_services/template/modules/kubernetes/services/jupyterhub/files/jupyterhub/01-theme.py
+++ b/src/_nebari/stages/kubernetes_services/template/modules/kubernetes/services/jupyterhub/files/jupyterhub/01-theme.py
@@ -14,4 +14,4 @@ c.JupyterHub.template_vars = {
 if z2jh.get_config("custom.jhub-apps-enabled"):
     from jhub_apps import themes
 
-    c.JupyterHub.template_vars = {**jupyterhub_theme, **themes.DEFAULT_THEME}
+    c.JupyterHub.template_vars = {**themes.DEFAULT_THEME, **jupyterhub_theme}


### PR DESCRIPTION
This PR change the order in which the theme values are applied. Currently the theme default values take priority.