### PR TITLE
get default variable value when following a terraform variable

### DIFF
--- a/scripts/helm-validate.py
+++ b/scripts/helm-validate.py
@@ -67,7 +67,7 @@ class HelmChartIndexer:
             var_name = self._clean_var_name(argument, "var")
             for var in parent_contents.get("variable", {}):
                 if var_name in var:
-                    return var[var_name]
+                    return var[var_name]["default"]
             else:
                 raise ValueError(f"Could not find variable {var_name}")
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://nebari.dev/community
-->

## Reference Issues or PRs
[This](https://github.com/nebari-dev/nebari/actions/runs/8272452121/job/22634293608) part of the release process was failing with error `ValueError: Could not find loki:{'description': 'version to deploy for the loki helm chart', 'type': '${string}', 'default': '5.43.3'} directory in helm_charts.`.  chart_version was being set to `{'description': 'version to deploy for the loki helm chart', 'type': '${string}', 'default': '5.43.3'}` instead of '5.43.3'.  This became an issue with the recent addition of loki.

I tested the change locally and it seems to run fine.  I'm not sure if there are other use cases where we would not want to grab the default value, but it does seem to run successfully when I run it locally.  Asking @viniciusdc to review since I believe he originally implemented this and may have more insight.
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create a link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

## What does this implement/fix?

_Put a `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds a feature)
- [ ] Breaking change (fix or feature that would cause existing features not to work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Other (please describe):

## Testing

- [x] Did you test the pull request locally?
- [ ] Did you add new tests? No

## Any other comments?

<!--
Please be aware that we are a loose team of volunteers, so patience is necessary;
assistance handling other issues is very welcome.
We value all user contributions. If we are slow to review, either the pull request needs some benchmarking, tinkering,
convincing, etc., or the reviewers are likely busy. In either case,
we ask for your understanding during the
review process.
Thanks for contributing to Nebari 🙏🏼!
-->
