### PR TITLE
Fix loki gateway url when deployed on non-dev namespace

### DIFF
--- a/src/_nebari/stages/kubernetes_services/template/modules/kubernetes/services/monitoring/main.tf
+++ b/src/_nebari/stages/kubernetes_services/template/modules/kubernetes/services/monitoring/main.tf
@@ -181,6 +181,14 @@ resource "helm_release" "prometheus-grafana" {
           "${var.node-group.key}" = var.node-group.value
         }
 
+        additionalDataSources = [
+          {
+            name = "Loki"
+            type = "loki"
+            url  = "http://loki-gateway.${var.namespace}"
+          }
+        ]
+
         # Avoid using the default password, as that's a security risk
         adminPassword : random_password.grafana_admin_password.result
 

--- a/src/_nebari/stages/kubernetes_services/template/modules/kubernetes/services/monitoring/values.yaml
+++ b/src/_nebari/stages/kubernetes_services/template/modules/kubernetes/services/monitoring/values.yaml
@@ -1,7 +1,1 @@
 # https://github.com/prometheus-community/helm-charts/blob/main/charts/kube-prometheus-stack/values.yaml
-
-grafana:
-  additionalDataSources:
-   - name: Loki
-     type: loki
-     url: http://loki-gateway.dev


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://nebari.dev/community
-->

## Reference Issues or PRs

It was accidentally assumed that Nebari will always be deployed on "dev" namespace, hence the constructed loki gateway url was not correct for non dev namespaces. This PR makes sure to incorporate namespace in gateway url.

<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create a link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

## What does this implement/fix?

_Put a `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds a feature)
- [ ] Breaking change (fix or feature that would cause existing features not to work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Other (please describe):

## Testing

- [ ] Did you test the pull request locally?
- [ ] Did you add new tests?

## Any other comments?

<!--
Please be aware that we are a loose team of volunteers, so patience is necessary;
assistance handling other issues is very welcome.
We value all user contributions. If we are slow to review, either the pull request needs some benchmarking, tinkering,
convincing, etc., or the reviewers are likely busy. In either case,
we ask for your understanding during the
review process.
Thanks for contributing to Nebari 🙏🏼!
-->
