### PR TITLE
Deduplicate conda-store in JupyterLab main menu

### DIFF
--- a/src/_nebari/stages/kubernetes_services/template/modules/kubernetes/services/jupyterhub/files/jupyterlab/overrides.json
+++ b/src/_nebari/stages/kubernetes_services/template/modules/kubernetes/services/jupyterhub/files/jupyterlab/overrides.json
@@ -51,7 +51,23 @@
                 "rank": 1000,
                 "items": [
                     {
-                        "command": "condastore:open",
+                        "command": "nebari:run-first-enabled",
+                        "args": {
+                            "commands": [
+                                {
+                                  "id": "condastore:open",
+                                  "label": "Environment Management"
+                                },
+                                {
+                                  "id": "help:open",
+                                  "args": {
+                                    "url": "/conda-store",
+                                    "text": "Environment Management",
+                                    "newBrowserTab": true
+                                  }
+                                }
+                            ]
+                        },
                         "rank": 1
                     },
                     {

--- a/src/_nebari/stages/kubernetes_services/template/modules/kubernetes/services/jupyterhub/files/jupyterlab/overrides.json
+++ b/src/_nebari/stages/kubernetes_services/template/modules/kubernetes/services/jupyterhub/files/jupyterlab/overrides.json
@@ -6,7 +6,8 @@
         "apiUrl": "/conda-store/",
         "authMethod": "cookie",
         "loginUrl": "/conda-store/login?next=",
-        "authToken": ""
+        "authToken": "",
+        "addMainMenuItem": false
     },
     "@jupyterlab/apputils-extension:notification": {
         "checkForUpdates": false,
@@ -50,13 +51,8 @@
                 "rank": 1000,
                 "items": [
                     {
-                        "command": "help:open",
-                        "rank": 1,
-                        "args": {
-                            "url": "/conda-store",
-                            "text": "Environment Management",
-                            "newBrowserTab": true
-                        }
+                        "command": "condastore:open",
+                        "rank": 1
                     },
                     {
                         "command": "help:open",


### PR DESCRIPTION
## Reference Issues or PRs

- Fixes #2326.
- Depends on https://github.com/nebari-dev/nebari-docker-images/pull/130

Uses `jupyterlab-conda-store` if available, fallbacks to opening `/conda-store` in new browser tab otherwise. The label in each case is set to "Environment Manager" (but we can adjust it).

### Before

- "Services > Environment Management" coming from nebari and opening conda-store in a new tab:
  ![image](https://github.com/nebari-dev/nebari/assets/5832902/6cb1722c-05b0-4051-90ed-0df7a48c0f84)
- "Conda-Store > Conda Store Package Manager" coming from `jupyterlab-conda-store`:
   ![image](https://github.com/nebari-dev/nebari/assets/5832902/fc67933d-010a-46e0-bedf-cfb655ae7d4b)

### After

- single "Services > Environment Manager" which opens `jupyterlab-conda-store` if available or `/conda-store` in new tab otherwise.

![image](https://github.com/nebari-dev/nebari/assets/5832902/b2d685a1-7851-42d9-8a4f-cc27a725993c)

## What does this implement/fix?

_Put a `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds a feature)
- [ ] Breaking change (fix or feature that would cause existing features not to work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Other (please describe):

## Testing

- [x] Did you test the pull request locally?
- [ ] Did you add new tests?
