### PR TITLE
PVC for Traefik Ingress (prevent LetsEncrypt throttling)

### DIFF
--- a/src/_nebari/stages/kubernetes_ingress/template/modules/kubernetes/ingress/main.tf
+++ b/src/_nebari/stages/kubernetes_ingress/template/modules/kubernetes/ingress/main.tf
@@ -9,7 +9,7 @@ locals {
       "--entrypoints.minio.http.tls.certResolver=letsencrypt",
       "--certificatesresolvers.letsencrypt.acme.tlschallenge",
       "--certificatesresolvers.letsencrypt.acme.email=${var.acme-email}",
-      "--certificatesresolvers.letsencrypt.acme.storage=acme.json",
+      "--certificatesresolvers.letsencrypt.acme.storage=/mnt/acme-certificates/acme.json",
       "--certificatesresolvers.letsencrypt.acme.caserver=${var.acme-server}",
     ]
     self-signed = local.default_cert
@@ -25,6 +25,23 @@ resource "kubernetes_service_account" "main" {
     name      = "${var.name}-traefik-ingress"
     namespace = var.namespace
   }
+}
+
+resource "kubernetes_persistent_volume_claim" "traefik_certs_pvc" {
+  metadata {
+    name = "traefik-ingress-certs"
+    namespace = var.namespace
+  }
+  spec {
+    access_modes = ["ReadWriteOnce"]
+    storage_class_name="gp2"
+    resources {
+      requests = {
+        storage = "5Gi"
+      }
+    }
+  }
+  wait_until_bound = false
 }
 
 
@@ -215,6 +232,10 @@ resource "kubernetes_deployment" "main" {
           image = "${var.traefik-image.image}:${var.traefik-image.tag}"
           name  = var.name
 
+          volume_mount { 
+            mount_path = "/mnt/acme-certificates"
+            name = "acme-certificates"
+          }
           security_context {
             capabilities {
               drop = ["ALL"]
@@ -324,6 +345,12 @@ resource "kubernetes_deployment" "main" {
             period_seconds        = 10
             failure_threshold     = 1
             success_threshold     = 1
+          }
+        }
+        volume { 
+          name = "acme-certificates"
+          persistent_volume_claim { 
+            claim_name = kubernetes_persistent_volume_claim.traefik_certs_pvc.metadata.0.name
           }
         }
       }

--- a/src/_nebari/stages/kubernetes_ingress/template/modules/kubernetes/ingress/main.tf
+++ b/src/_nebari/stages/kubernetes_ingress/template/modules/kubernetes/ingress/main.tf
@@ -29,12 +29,11 @@ resource "kubernetes_service_account" "main" {
 
 resource "kubernetes_persistent_volume_claim" "traefik_certs_pvc" {
   metadata {
-    name = "traefik-ingress-certs"
+    name      = "traefik-ingress-certs"
     namespace = var.namespace
   }
   spec {
     access_modes = ["ReadWriteOnce"]
-    storage_class_name="gp2"
     resources {
       requests = {
         storage = "5Gi"
@@ -232,9 +231,9 @@ resource "kubernetes_deployment" "main" {
           image = "${var.traefik-image.image}:${var.traefik-image.tag}"
           name  = var.name
 
-          volume_mount { 
+          volume_mount {
             mount_path = "/mnt/acme-certificates"
-            name = "acme-certificates"
+            name       = "acme-certificates"
           }
           security_context {
             capabilities {
@@ -347,9 +346,9 @@ resource "kubernetes_deployment" "main" {
             success_threshold     = 1
           }
         }
-        volume { 
+        volume {
           name = "acme-certificates"
-          persistent_volume_claim { 
+          persistent_volume_claim {
             claim_name = kubernetes_persistent_volume_claim.traefik_certs_pvc.metadata.0.name
           }
         }


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://nebari.dev/community
-->

## Reference Issues or PRs

<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create a link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

## What does this implement/fix?

This is an interim fix for #2174 .  It sets up a PVC for the traefik ingress pod so that the cert is on persistent storage, meaning that as new pods get recreated, they will not request new certs (which leads to the throttling problem mentioned in the issue).

The "best fix" is cert-manager or another service will handle all these requests.  That's being worked on - ref #2336 

In AWS, the storage class it uses is EBS-backed and therefore specific to an AZ, which means that this is not truly HA / fault tolerant (the pod will always schedule and launch on a node in the same AZ).  However, there are many resources in the kubernetes_services stage that follow this same pattern so this is not introducing a new limitation, and is only intended as an interim fix anyway.

Note I have ONLY tested this in AWS.  Need assistance running in other clouds.  Specifically, I am not sure that the access_mode will be universal because it is relying on Kubernetes to determine the default storage class and create the volume.  This seems to work OK for helm charts that do this within the `kubernetes_services` stage but this resource gets created in a prior stage, so there could be some dependency/configuration that I am missing.

_Put a `x` in the boxes that apply_

- [ X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds a feature)
- [ ] Breaking change (fix or feature that would cause existing features not to work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Other (please describe):

## Testing

- [X ] Did you test the pull request locally?
Local and AWS cloud
- [ ] Did you add new tests?

## Any other comments?

<!--
Please be aware that we are a loose team of volunteers, so patience is necessary;
assistance handling other issues is very welcome.
We value all user contributions. If we are slow to review, either the pull request needs some benchmarking, tinkering,
convincing, etc., or the reviewers are likely busy. In either case,
we ask for your understanding during the
review process.
Thanks for contributing to Nebari 🙏🏼!
-->
