### PR TITLE
Get JupyterHub `groups` from Keycloak, support `oauthenticator` 16.3+

### DIFF
--- a/src/_nebari/stages/kubernetes_services/template/modules/kubernetes/services/jupyterhub/main.tf
+++ b/src/_nebari/stages/kubernetes_services/template/modules/kubernetes/services/jupyterhub/main.tf
@@ -150,25 +150,25 @@ resource "helm_release" "jupyterhub" {
             enable_auth_state = true
           }
           GenericOAuthenticator = {
-            client_id          = module.jupyterhub-openid-client.config.client_id
-            client_secret      = module.jupyterhub-openid-client.config.client_secret
-            oauth_callback_url = "https://${var.external-url}/hub/oauth_callback"
-            authorize_url      = module.jupyterhub-openid-client.config.authentication_url
-            token_url          = module.jupyterhub-openid-client.config.token_url
-            userdata_url       = module.jupyterhub-openid-client.config.userinfo_url
-            login_service      = "Keycloak"
-            username_claim     = "preferred_username"
-            claim_groups_key   = "groups"
-            allowed_groups     = ["jupyterhub_admin", "jupyterhub_developer"]
-            admin_groups       = ["jupyterhub_admin"]
-            manage_groups      = true
-            refresh_pre_spawn  = true
+            client_id            = module.jupyterhub-openid-client.config.client_id
+            client_secret        = module.jupyterhub-openid-client.config.client_secret
+            oauth_callback_url   = "https://${var.external-url}/hub/oauth_callback"
+            authorize_url        = module.jupyterhub-openid-client.config.authentication_url
+            token_url            = module.jupyterhub-openid-client.config.token_url
+            userdata_url         = module.jupyterhub-openid-client.config.userinfo_url
+            login_service        = "Keycloak"
+            username_claim       = "preferred_username"
+            claim_groups_key     = "groups"
+            allowed_groups       = ["jupyterhub_admin", "jupyterhub_developer"]
+            admin_groups         = ["jupyterhub_admin"]
+            manage_groups        = true
+            refresh_pre_spawn    = true
             validate_server_cert = false
 
             # deprecated, to be removed (replaced by validate_server_cert)
-            tls_verify         = false
+            tls_verify = false
             # deprecated, to be removed (replaced by username_claim)
-            username_key       = "preferred_username"
+            username_key = "preferred_username"
           }
         }
       }

--- a/src/_nebari/stages/kubernetes_services/template/modules/kubernetes/services/jupyterhub/main.tf
+++ b/src/_nebari/stages/kubernetes_services/template/modules/kubernetes/services/jupyterhub/main.tf
@@ -159,8 +159,8 @@ resource "helm_release" "jupyterhub" {
             login_service        = "Keycloak"
             username_claim       = "preferred_username"
             claim_groups_key     = "groups"
-            allowed_groups       = ["jupyterhub_admin", "jupyterhub_developer"]
-            admin_groups         = ["jupyterhub_admin"]
+            allowed_groups       = ["/analyst", "/developer", "/admin"]
+            admin_groups         = ["/admin"]
             manage_groups        = true
             refresh_pre_spawn    = true
             validate_server_cert = false

--- a/src/_nebari/stages/kubernetes_services/template/modules/kubernetes/services/jupyterhub/main.tf
+++ b/src/_nebari/stages/kubernetes_services/template/modules/kubernetes/services/jupyterhub/main.tf
@@ -157,11 +157,18 @@ resource "helm_release" "jupyterhub" {
             token_url          = module.jupyterhub-openid-client.config.token_url
             userdata_url       = module.jupyterhub-openid-client.config.userinfo_url
             login_service      = "Keycloak"
-            username_key       = "preferred_username"
-            claim_groups_key   = "roles"
+            username_claim     = "preferred_username"
+            claim_groups_key   = "groups"
             allowed_groups     = ["jupyterhub_admin", "jupyterhub_developer"]
             admin_groups       = ["jupyterhub_admin"]
+            manage_groups      = true
+            refresh_pre_spawn  = true
+            validate_server_cert = false
+
+            # deprecated, to be removed (replaced by validate_server_cert)
             tls_verify         = false
+            # deprecated, to be removed (replaced by username_claim)
+            username_key       = "preferred_username"
           }
         }
       }


### PR DESCRIPTION
## Reference Issues or PRs

- A task for https://github.com/nebari-dev/nebari/issues/2308
- Can be merged straightaway but for the `groups` to get populated from keycloak requires https://github.com/nebari-dev/nebari-docker-images/pull/131

## What does this implement/fix?

_Put a `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds a feature)
- [ ] Breaking change (fix or feature that would cause existing features not to work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Other (please describe):

## Testing

- [x] Did you test the pull request locally?
- [ ] Did you add new tests?

To test:

1. Set the image to use https://github.com/nebari-dev/nebari-docker-images/pull/131:
  ```
  default_images:
    jupyterhub: quay.io/nebari/nebari-jupyterhub:oauthenticator-16.3.0
  ```
2. Deploy
3. Open https://your-nebari-deployment/hub/token
4. Open Dev Tools in your browser, switch to Network tab
5. Press "Request new API token"
6. Right click on the request in Network tab → copy as fetch
7. Paste the request, change method to "GET", remove "body", change URL to `/hub/api/users`
8. Re-send the request
9. Click on the new request, preview the response
10. It should contain groups from keycloak e.g.:
  ```json
  [
      {
          "kind": "user",
          "auth_state": null,
          "groups": [
              "grafana_developer",
              "query-users",
              "manage-identity-providers",
              "manage-clients",
              "manage-account",
              "manage-realm",
              "view-profile",
              "argo-admin",
              "dask_gateway_developer",
              "grafana_admin",
              "view-identity-providers",
              "jupyterhub_admin",
              "view-realm",
              "view-authorization",
              "jupyterhub_developer",
              "view-clients",
              "query-groups",
              "conda_store_developer",
              "view-events",
              "query-realms",
              "impersonation",
              "realm-admin",
              "create-client",
              "conda_store_superadmin",
              "argo-viewer",
              "argo-developer",
              "manage-events",
              "grafana_viewer",
              "manage-users",
              "dask_gateway_admin",
              "manage-account-links",
              "manage-authorization",
              "query-clients",
              "view-users",
              "conda_store_admin"
          ],
          "admin": true,
          "roles": [
              "user",
              "admin"
          ],
          "name": "USER",
          "pending": null,
          "server": "/user/USER/",
          "servers": {
              "": {
                  "name": "",
                  "pending": null,
                  "ready": true,
                  "stopped": false,
                  "url": "/user/USER/",
                  "user_options": {
                      "profile": "small-instance"
                  },
                  "progress_url": "/hub/api/users/USER/server/progress",
                  "state": {
                      "pod_name": "jupyter-USER"
                  }
              }
          }
      }
  ]
  ```
  

## Any other comments?

<!--
Please be aware that we are a loose team of volunteers, so patience is necessary;
assistance handling other issues is very welcome.
We value all user contributions. If we are slow to review, either the pull request needs some benchmarking, tinkering,
convincing, etc., or the reviewers are likely busy. In either case,
we ask for your understanding during the
review process.
Thanks for contributing to Nebari 🙏🏼!
-->
