### PR TITLE
Avoid cloud-provider CI/CD test via repo-scoped variable [do not merge]

### DIFF
--- a/.github/workflows/test-provider.yaml
+++ b/.github/workflows/test-provider.yaml
@@ -32,8 +32,10 @@ on:
 
 jobs:
   test-render-providers:
-    # avoid running on PRs coming from a fork
-    if: github.event.pull_request.head.repo.full_name == github.repository || github.event_name != 'pull_request'
+    # Mechanism to prevent this test from running
+    # - on forks whose maintainers specify that provider credentials are absent (by setting env NO_PROVIDER_CREDENTIALS)
+    # - on PRs coming from a fork (in which case the destination fork's provider credentials do not currently work)
+    if: ${{ env.NO_PROVIDER_CREDENTIALS == '' }} && (github.event.pull_request.head.repo.full_name == github.repository || github.event_name != 'pull_request')
     name: "Test Nebari Provider"
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
This is a test to see if the repo variable method works