### PR TITLE
Make CI/CD Cloud Provider Test Conditional

### DIFF
--- a/.github/workflows/test-provider.yaml
+++ b/.github/workflows/test-provider.yaml
@@ -59,9 +59,6 @@ jobs:
           - gitlab-ci
       fail-fast: false
     steps:
-      - name: "Debug Print NO_PROVIDER_CREDENTIALS"
-        run:  echo ${{ vars.NO_PROVIDER_CREDENTIALS }}
-
       - name: "Checkout Infrastructure"
         uses: actions/checkout@v4
 
@@ -70,7 +67,6 @@ jobs:
         run: hub pr checkout ${{ inputs.pr_number }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          #NO_PROVIDER_CREDENTIALS: ${{ vars.NO_PROVIDER_CREDENTIALS }}
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.github/workflows/test-provider.yaml
+++ b/.github/workflows/test-provider.yaml
@@ -32,8 +32,12 @@ on:
 
 jobs:
   test-render-providers:
-    # avoid running on PRs coming from a fork
-    if: github.event.pull_request.head.repo.full_name == github.repository || github.event_name != 'pull_request'
+    # Mechanism to prevent this test from running
+    # - on forks whose maintainers specify that provider credentials are absent (by setting a github variable NO_PROVIDER_CREDENTIALS)
+    # - on PRs coming from a fork (in which case github does not make the destination fork's credentials available)
+    if: |
+      vars.NO_PROVIDER_CREDENTIALS == '' &&
+      (github.event.pull_request.head.repo.full_name == github.repository || github.event_name != 'pull_request')
     name: "Test Nebari Provider"
     runs-on: ubuntu-latest
     permissions:
@@ -55,6 +59,9 @@ jobs:
           - gitlab-ci
       fail-fast: false
     steps:
+      - name: "Debug Print NO_PROVIDER_CREDENTIALS"
+        run:  echo ${{ vars.NO_PROVIDER_CREDENTIALS }}
+
       - name: "Checkout Infrastructure"
         uses: actions/checkout@v4
 
@@ -63,6 +70,7 @@ jobs:
         run: hub pr checkout ${{ inputs.pr_number }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          #NO_PROVIDER_CREDENTIALS: ${{ vars.NO_PROVIDER_CREDENTIALS }}
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.github/workflows/test-provider.yaml
+++ b/.github/workflows/test-provider.yaml
@@ -32,9 +32,10 @@ on:
 
 jobs:
   test-render-providers:
-    # Mechanism to prevent this test from running
-    # - on forks whose maintainers specify that provider credentials are absent (by setting a github variable NO_PROVIDER_CREDENTIALS)
-    # - on PRs coming from a fork (in which case github does not make the destination fork's credentials available)
+    # Prevents the execution of this test under the following conditions:
+    # 1. When the 'NO_PROVIDER_CREDENTIALS' GitHub variable is set, indicating the absence of provider credentials.
+    # 2. For pull requests (PRs) originating from a fork, since GitHub does not provide the fork's credentials to the destination repository.
+    # ref. https://github.com/nebari-dev/nebari/issues/2379
     if: |
       vars.NO_PROVIDER_CREDENTIALS == '' &&
       (github.event.pull_request.head.repo.full_name == github.repository || github.event_name != 'pull_request')


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://nebari.dev/community
-->

## Reference Issues or PRs

<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create a link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

## What does this implement/fix?
The cloud provider CI/CD test fails when run from forks of this repo which do not have credentials (and presumably, their own accounts) set up for the providers used by the test. This situation generates spurious CI/CD pipeline failure messages.

This PR adds the ability for repo fork maintainers to skip the CI/CD Cloud Provider Test by setting a repo variable 'NO_PROVIDER_CREDENTIALS'. If that variable is ***not set*** by the repo maintainer (the default case), the test behavior will be unchanged from before this PR.

_Put a `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds a feature)
- [ ] Breaking change (fix or feature that would cause existing features not to work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [X] Build related changes
- [ ] Other (please describe):

## Testing

- [X] Did you test the pull request locally?
- [ ] Did you add new tests?

## Any other comments?

<!--
Please be aware that we are a loose team of volunteers, so patience is necessary;
assistance handling other issues is very welcome.
We value all user contributions. If we are slow to review, either the pull request needs some benchmarking, tinkering,
convincing, etc., or the reviewers are likely busy. In either case,
we ask for your understanding during the
review process.
Thanks for contributing to Nebari 🙏🏼!
-->
