### PR TITLE
update azurerm version

### DIFF
--- a/src/_nebari/stages/infrastructure/template/azure/versions.tf
+++ b/src/_nebari/stages/infrastructure/template/azure/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "=3.22.0"
+      version = "=3.97.1"
     }
   }
   required_version = ">= 1.0"

--- a/src/_nebari/stages/terraform_state/template/azure/main.tf
+++ b/src/_nebari/stages/terraform_state/template/azure/main.tf
@@ -47,7 +47,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "=3.22.0"
+      version = "=3.97.1"
     }
   }
   required_version = ">= 1.0"


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://nebari.dev/community
-->

## Reference Issues or PRs
Fixes https://github.com/nebari-dev/nebari/issues/2374

Azurerm was throwing the following error on deployment in eastus2 region when updating a cluster from 2024.1.1 to 2024.3.3.

```
Error: retrieving Cluster: (Managed Cluster Name "nebari-dev" / Resource Group "my-resourcegroup"): 
containerservice.ManagedClustersClient#Get: Failure respond ing to request: StatusCode=400 -- 
Original Error: autorest/azure: Service returned an error. Status=400 Code="NoRegisteredProviderFound" 
Message="No registered resource provider found for location 'eastus2' and API version '2022-03-02-preview' for type 'managedClusters'.
```

Updating azurerm provider fixed the issue.
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create a link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

## What does this implement/fix?

_Put a `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds a feature)
- [ ] Breaking change (fix or feature that would cause existing features not to work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [x] Other (please describe):  Update azurerm

## Testing

- [x] Did you test the pull request locally?
- [ ] Did you add new tests?

## Any other comments?

<!--
Please be aware that we are a loose team of volunteers, so patience is necessary;
assistance handling other issues is very welcome.
We value all user contributions. If we are slow to review, either the pull request needs some benchmarking, tinkering,
convincing, etc., or the reviewers are likely busy. In either case,
we ask for your understanding during the
review process.
Thanks for contributing to Nebari 🙏🏼!
-->
