### PR TITLE
add full names for cloud providers in guided init

### DIFF
--- a/src/_nebari/subcommands/init.py
+++ b/src/_nebari/subcommands/init.py
@@ -75,6 +75,15 @@ DEFAULT_KUBERNETES_VERSION_MSG = (
 
 LATEST = "latest"
 
+CLOUD_PROVIDER_FULL_NAME = {
+    "Local": ProviderEnum.local.name,
+    "Existing": ProviderEnum.existing.name,
+    "Digital Ocean": ProviderEnum.do.name,
+    "Amazon Web Services": ProviderEnum.aws.name,
+    "Google Cloud Platform": ProviderEnum.gcp.name,
+    "Microsoft Azure": ProviderEnum.azure.name,
+}
+
 
 class GitRepoEnum(str, enum.Enum):
     github = "github.com"
@@ -647,11 +656,13 @@ def guided_init_wizard(ctx: typer.Context, guided_init: str):
             )
         )
         # try:
-        inputs.cloud_provider = questionary.select(
+        cloud_provider: str = questionary.select(
             "Where would you like to deploy your Nebari cluster?",
-            choices=enum_to_list(ProviderEnum),
+            choices=CLOUD_PROVIDER_FULL_NAME.keys(),
             qmark=qmark,
         ).unsafe_ask()
+
+        inputs.cloud_provider = CLOUD_PROVIDER_FULL_NAME.get(cloud_provider)
 
         if not disable_checks:
             check_cloud_provider_creds(


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://nebari.dev/community
-->

## Reference Issues or PRs
Fixes #1708 
PR #1744 was made for this before and @iameskild had described [a good solution](https://github.com/nebari-dev/nebari/pull/1744/files#r1198403593), but the difficulties faced last time arose due to the fact that there's a pydantic root validator in place which then doesn't allow `inputs.cloud_provider` to store full cloud provider names outright. The feature can be implemented by simply using a new variable to hold the inputs from the user and then still passing the accepted enum vals on to `inputs.cloud_provider`.
It's a very very minor change!
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create a link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

## What does this implement/fix?

_Put a `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds a feature)
- [ ] Breaking change (fix or feature that would cause existing features not to work as expected)
- [ ] Documentation Update
- [ x ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Other (please describe):

## Testing

- [ x ] Did you test the pull request locally?
- [ ] Did you add new tests?

## Any other comments?

<!--
Please be aware that we are a loose team of volunteers, so patience is necessary;
assistance handling other issues is very welcome.
We value all user contributions. If we are slow to review, either the pull request needs some benchmarking, tinkering,
convincing, etc., or the reviewers are likely busy. In either case,
we ask for your understanding during the
review process.
Thanks for contributing to Nebari 🙏🏼!
-->
