### PR TITLE
Fetch JupyterHub roles from Keycloak

### DIFF
--- a/src/_nebari/stages/kubernetes_services/template/modules/kubernetes/services/jupyterhub/files/jupyterhub/02-spawner.py
+++ b/src/_nebari/stages/kubernetes_services/template/modules/kubernetes/services/jupyterhub/files/jupyterhub/02-spawner.py
@@ -73,6 +73,7 @@ if z2jh.get_config("custom.jhub-apps-enabled"):
                 "external": True,
             },
             "oauth_no_confirm": True,
+            "oauth_redirect_uri": "/services/:name/oauth_callback",
         }
 
     c.JupyterHub.services.extend(

--- a/src/_nebari/stages/kubernetes_services/template/modules/kubernetes/services/jupyterhub/files/jupyterhub/04-auth.py
+++ b/src/_nebari/stages/kubernetes_services/template/modules/kubernetes/services/jupyterhub/files/jupyterhub/04-auth.py
@@ -31,7 +31,7 @@ class KeyCloakOAuthenticator(GenericOAuthenticator):
         auth_model = await super().update_auth_model(auth_model)
         user_info = auth_model["auth_state"][self.user_auth_state_key]
         user_roles = self._get_user_roles(user_info)
-        auth_model["roles"] = user_roles
+        auth_model["roles"] = [{"name": role_name} for role_name in user_roles]
         return auth_model
 
     async def load_managed_roles(self):

--- a/src/_nebari/stages/kubernetes_services/template/modules/kubernetes/services/jupyterhub/files/jupyterhub/04-auth.py
+++ b/src/_nebari/stages/kubernetes_services/template/modules/kubernetes/services/jupyterhub/files/jupyterhub/04-auth.py
@@ -32,6 +32,11 @@ class KeyCloakOAuthenticator(GenericOAuthenticator):
         user_info = auth_model["auth_state"][self.user_auth_state_key]
         user_roles = self._get_user_roles(user_info)
         auth_model["roles"] = [{"name": role_name} for role_name in user_roles]
+        # note: because the roles check is comprehensive, we need to re-add the admin and user roles
+        if auth_model["admin"]:
+            auth_model["roles"].append({"name": "admin"})
+        if self.check_allowed(auth_model["name"], auth_model):
+            auth_model["roles"].append({"name": "user"})
         return auth_model
 
     async def load_managed_roles(self):

--- a/src/_nebari/stages/kubernetes_services/template/modules/kubernetes/services/jupyterhub/files/jupyterhub/04-auth.py
+++ b/src/_nebari/stages/kubernetes_services/template/modules/kubernetes/services/jupyterhub/files/jupyterhub/04-auth.py
@@ -5,7 +5,7 @@ from functools import reduce
 
 from jupyterhub.traitlets import Callable
 from oauthenticator.generic import GenericOAuthenticator
-from traitlets import Unicode, Union
+from traitlets import Bool, Unicode, Union
 
 
 class KeyCloakOAuthenticator(GenericOAuthenticator):
@@ -25,7 +25,7 @@ class KeyCloakOAuthenticator(GenericOAuthenticator):
         config=True, help="""The keycloak REST API URL for the realm."""
     )
 
-    service_account_user_id = Unicode(config=True, help="""service_account_user_id.""")
+    reset_managed_roles_on_startup = Bool(True)
 
     async def update_auth_model(self, auth_model):
         auth_model = await super().update_auth_model(auth_model)

--- a/src/_nebari/stages/kubernetes_services/template/modules/kubernetes/services/jupyterhub/files/jupyterhub/04-auth.py
+++ b/src/_nebari/stages/kubernetes_services/template/modules/kubernetes/services/jupyterhub/files/jupyterhub/04-auth.py
@@ -1,0 +1,128 @@
+import json
+import os
+import urllib
+from functools import reduce
+
+from jupyterhub.traitlets import Callable
+from oauthenticator.generic import GenericOAuthenticator
+from traitlets import Unicode, Union
+
+
+class KeyCloakOAuthenticator(GenericOAuthenticator):
+    """
+    Since `oauthenticator` 16.3 `GenericOAuthenticator` supports group management.
+    This subclass adds role management on top of it, building on the new `manage_roles`
+    feature added in JupyterHub 5.0 (https://github.com/jupyterhub/jupyterhub/pull/4748).
+    """
+
+    claim_roles_key = Union(
+        [Unicode(os.environ.get("OAUTH2_ROLES_KEY", "groups")), Callable()],
+        config=True,
+        help="""As `claim_groups_key` but for roles.""",
+    )
+
+    realm_api_url = Unicode(
+        config=True, help="""The keycloak REST API URL for the realm."""
+    )
+
+    service_account_user_id = Unicode(config=True, help="""service_account_user_id.""")
+
+    async def update_auth_model(self, auth_model):
+        auth_model = await super().update_auth_model(auth_model)
+        user_info = auth_model["auth_state"][self.user_auth_state_key]
+        user_roles = self._get_user_roles(user_info)
+        auth_model["roles"] = user_roles
+        return auth_model
+
+    async def load_managed_roles(self):
+        if not self.manage_roles:
+            raise ValueError(
+                "Managed roles can only be loaded when `manage_roles` is True"
+            )
+        token = await self._get_token()
+
+        # Get the clients list to find the "id" of "jupyterhub" client.
+        clients_data = await self._fetch_api(endpoint="clients/", token=token)
+        jupyterhub_clients = [
+            client for client in clients_data if client["clientId"] == "jupyterhub"
+        ]
+        assert len(jupyterhub_clients) == 1
+        jupyterhub_client_id = jupyterhub_clients[0]["id"]
+
+        # Includes roles like "jupyterhub_admin", "jupyterhub_developer", "dask_gateway_developer"
+        client_roles = await self._fetch_api(
+            endpoint=f"clients/{jupyterhub_client_id}/roles", token=token
+        )
+        # Includes roles like "default-roles-nebari", "offline_access", "uma_authorization"
+        realm_roles = await self._fetch_api(endpoint="roles", token=token)
+        roles = {
+            role["name"]: {"name": role["name"], "description": role["description"]}
+            for role in [*realm_roles, *client_roles]
+        }
+        # we could use either `name` (e.g. "developer") or `path` ("/developer");
+        # since the default claim key returns `path`, it seems preferable.
+        group_name_key = "path"
+        for realm_role in realm_roles:
+            role_name = realm_role["name"]
+            role = roles[role_name]
+            # fetch role assignments to groups
+            groups = await self._fetch_api(f"roles/{role_name}/groups", token=token)
+            role["groups"] = [group[group_name_key] for group in groups]
+            # fetch role assignments to users
+            users = await self._fetch_api(f"roles/{role_name}/users", token=token)
+            role["users"] = [user["username"] for user in users]
+        for client_role in client_roles:
+            role_name = client_role["name"]
+            role = roles[role_name]
+            # fetch role assignments to groups
+            groups = await self._fetch_api(
+                f"clients/{jupyterhub_client_id}/roles/{role_name}/groups", token=token
+            )
+            role["groups"] = [group[group_name_key] for group in groups]
+            # fetch role assignments to users
+            users = await self._fetch_api(
+                f"clients/{jupyterhub_client_id}/roles/{role_name}/users", token=token
+            )
+            role["users"] = [user["username"] for user in users]
+
+        return list(roles.values())
+
+    def _get_user_roles(self, user_info):
+        if callable(self.claim_roles_key):
+            return set(self.claim_roles_key(user_info))
+        try:
+            return set(reduce(dict.get, self.claim_roles_key.split("."), user_info))
+        except TypeError:
+            self.log.error(
+                f"The claim_roles_key {self.claim_roles_key} does not exist in the user token"
+            )
+            return set()
+
+    async def _get_token(self) -> str:
+        http = self.http_client
+
+        body = urllib.parse.urlencode(
+            {
+                "client_id": self.client_id,
+                "client_secret": self.client_secret,
+                "grant_type": "client_credentials",
+            }
+        )
+        response = await http.fetch(
+            self.token_url,
+            method="POST",
+            body=body,
+        )
+        data = json.loads(response.body)
+        return data["access_token"]  # type: ignore[no-any-return]
+
+    async def _fetch_api(self, endpoint: str, token: str):
+        response = await self.http_client.fetch(
+            f"{self.realm_api_url}/{endpoint}",
+            method="GET",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        return json.loads(response.body)
+
+
+c.JupyterHub.authenticator_class = KeyCloakOAuthenticator

--- a/src/_nebari/stages/kubernetes_services/template/modules/kubernetes/services/jupyterhub/main.tf
+++ b/src/_nebari/stages/kubernetes_services/template/modules/kubernetes/services/jupyterhub/main.tf
@@ -57,7 +57,7 @@ resource "helm_release" "jupyterhub" {
 
   repository = "https://jupyterhub.github.io/helm-chart/"
   chart      = "jupyterhub"
-  version    = "3.2.1"
+  version    = "4.0.0-0.dev.git.6586.h0a16e5a0"
 
   values = concat([
     file("${path.module}/values.yaml"),

--- a/src/_nebari/stages/kubernetes_services/template/modules/kubernetes/services/jupyterhub/main.tf
+++ b/src/_nebari/stages/kubernetes_services/template/modules/kubernetes/services/jupyterhub/main.tf
@@ -148,24 +148,24 @@ resource "helm_release" "jupyterhub" {
             enable_auth_state = true
           }
           KeyCloakOAuthenticator = {
-            client_id                      = module.jupyterhub-openid-client.config.client_id
-            client_secret                  = module.jupyterhub-openid-client.config.client_secret
-            oauth_callback_url             = "https://${var.external-url}/hub/oauth_callback"
-            authorize_url                  = module.jupyterhub-openid-client.config.authentication_url
-            token_url                      = module.jupyterhub-openid-client.config.token_url
-            realm_api_url                  = module.jupyterhub-openid-client.config.realm_api_url
-            service_account_user_id        = module.jupyterhub-openid-client.config.service_account_user_id
-            login_service                  = "Keycloak"
-            username_claim                 = "preferred_username"
-            claim_groups_key               = "groups"
-            claim_roles_key                = "roles"
-            allowed_groups                 = ["/analyst", "/developer", "/admin"]
-            admin_groups                   = ["/admin"]
-            manage_groups                  = true
-            manage_roles                   = true
-            reset_managed_roles_on_startup = true
-            refresh_pre_spawn              = true
-            validate_server_cert           = false
+            client_id            = module.jupyterhub-openid-client.config.client_id
+            client_secret        = module.jupyterhub-openid-client.config.client_secret
+            oauth_callback_url   = "https://${var.external-url}/hub/oauth_callback"
+            authorize_url        = module.jupyterhub-openid-client.config.authentication_url
+            token_url            = module.jupyterhub-openid-client.config.token_url
+            userdata_url         = module.jupyterhub-openid-client.config.userinfo_url
+            realm_api_url        = module.jupyterhub-openid-client.config.realm_api_url
+            service_account_id   = module.jupyterhub-openid-client.config.service_account_user_id
+            login_service        = "Keycloak"
+            username_claim       = "preferred_username"
+            claim_groups_key     = "groups"
+            claim_roles_key      = "roles"
+            allowed_groups       = ["/analyst", "/developer", "/admin"]
+            admin_groups         = ["/admin"]
+            manage_groups        = true
+            manage_roles         = true
+            refresh_pre_spawn    = true
+            validate_server_cert = false
 
             # deprecated, to be removed (replaced by validate_server_cert)
             tls_verify = false

--- a/src/_nebari/stages/kubernetes_services/template/modules/kubernetes/services/jupyterhub/main.tf
+++ b/src/_nebari/stages/kubernetes_services/template/modules/kubernetes/services/jupyterhub/main.tf
@@ -155,7 +155,6 @@ resource "helm_release" "jupyterhub" {
             token_url            = module.jupyterhub-openid-client.config.token_url
             userdata_url         = module.jupyterhub-openid-client.config.userinfo_url
             realm_api_url        = module.jupyterhub-openid-client.config.realm_api_url
-            service_account_id   = module.jupyterhub-openid-client.config.service_account_user_id
             login_service        = "Keycloak"
             username_claim       = "preferred_username"
             claim_groups_key     = "groups"

--- a/src/_nebari/stages/kubernetes_services/template/modules/kubernetes/services/keycloak-client/outputs.tf
+++ b/src/_nebari/stages/kubernetes_services/template/modules/kubernetes/services/keycloak-client/outputs.tf
@@ -1,12 +1,14 @@
 output "config" {
   description = "configuration credentials for connecting to openid client"
   value = {
-    client_id     = keycloak_openid_client.main.client_id
-    client_secret = keycloak_openid_client.main.client_secret
+    client_id               = keycloak_openid_client.main.client_id
+    client_secret           = keycloak_openid_client.main.client_secret
+    service_account_user_id = keycloak_openid_client.main.service_account_user_id
 
     authentication_url = "https://${var.external-url}/auth/realms/${var.realm_id}/protocol/openid-connect/auth"
     token_url          = "https://${var.external-url}/auth/realms/${var.realm_id}/protocol/openid-connect/token"
     userinfo_url       = "https://${var.external-url}/auth/realms/${var.realm_id}/protocol/openid-connect/userinfo"
+    realm_api_url      = "https://${var.external-url}/auth/admin/realms/${var.realm_id}"
     callback_urls      = var.callback-url-paths
   }
 }

--- a/src/_nebari/stages/kubernetes_services/template/modules/kubernetes/services/keycloak-client/variables.tf
+++ b/src/_nebari/stages/kubernetes_services/template/modules/kubernetes/services/keycloak-client/variables.tf
@@ -16,6 +16,19 @@ variable "external-url" {
 }
 
 
+variable "service-accounts-enabled" {
+  description = "Whether the client should have a service account created"
+  type        = bool
+  default     = false
+}
+
+variable "service-account-roles" {
+  description = "Roles to be granted to the service account. Requires setting service-accounts-enabled to true."
+  type        = list(string)
+  default     = []
+}
+
+
 variable "role_mapping" {
   description = "Group to role mapping to establish for client"
   type        = map(list(string))

--- a/tests/tests_deployment/test_jupyterhub_api.py
+++ b/tests/tests_deployment/test_jupyterhub_api.py
@@ -14,7 +14,7 @@ def test_jupyterhub_loads_roles_from_keycloak():
         verify=False,
     )
     user = response.json()
-    assert user["roles"] == [
+    assert set(user["roles"]) == {
         "user",
         "manage-account",
         "jupyterhub_developer",
@@ -26,7 +26,7 @@ def test_jupyterhub_loads_roles_from_keycloak():
         "grafana_developer",
         "manage-account-links",
         "view-profile",
-    ]
+    }
 
 
 @pytest.mark.filterwarnings("ignore::urllib3.exceptions.InsecureRequestWarning")
@@ -39,4 +39,4 @@ def test_jupyterhub_loads_groups_from_keycloak():
         verify=False,
     )
     user = response.json()
-    assert user["groups"] == ["/analyst", "/developer", "/users"]
+    assert set(user["groups"]) == {"/analyst", "/developer", "/users"}

--- a/tests/tests_deployment/test_jupyterhub_api.py
+++ b/tests/tests_deployment/test_jupyterhub_api.py
@@ -1,6 +1,7 @@
 import pytest
 
 from tests.tests_deployment import constants
+from tests.tests_deployment.utils import get_jupyterhub_session
 
 
 @pytest.mark.filterwarnings("ignore::urllib3.exceptions.InsecureRequestWarning")
@@ -8,10 +9,34 @@ def test_jupyterhub_loads_roles_from_keycloak():
     session = get_jupyterhub_session()
     xsrf_token = session.cookies.get("_xsrf")
     response = session.get(
-        f"https://{constants.NEBARI_HOSTNAME}/hub/api/users",
+        f"https://{constants.NEBARI_HOSTNAME}/hub/api/users/{constants.KEYCLOAK_USERNAME}",
         headers={"X-XSRFToken": xsrf_token},
         verify=False,
     )
-    users = response.json()
-    print(users)
-    assert users[0]["roles"] == []
+    user = response.json()
+    assert user["roles"] == [
+        "user",
+        "manage-account",
+        "jupyterhub_developer",
+        "argo-developer",
+        "dask_gateway_developer",
+        "grafana_viewer",
+        "conda_store_developer",
+        "argo-viewer",
+        "grafana_developer",
+        "manage-account-links",
+        "view-profile",
+    ]
+
+
+@pytest.mark.filterwarnings("ignore::urllib3.exceptions.InsecureRequestWarning")
+def test_jupyterhub_loads_groups_from_keycloak():
+    session = get_jupyterhub_session()
+    xsrf_token = session.cookies.get("_xsrf")
+    response = session.get(
+        f"https://{constants.NEBARI_HOSTNAME}/hub/api/users/{constants.KEYCLOAK_USERNAME}",
+        headers={"X-XSRFToken": xsrf_token},
+        verify=False,
+    )
+    user = response.json()
+    assert user["groups"] == ["/analyst", "/developer", "/users"]

--- a/tests/tests_deployment/test_jupyterhub_api.py
+++ b/tests/tests_deployment/test_jupyterhub_api.py
@@ -1,20 +1,15 @@
 import pytest
-import requests
 
 from tests.tests_deployment import constants
-from tests.tests_deployment.utils import get_jupyterhub_token
-
-
-@pytest.fixture(scope="session")
-def api_token():
-    return get_jupyterhub_token("jupyterhub-api")
 
 
 @pytest.mark.filterwarnings("ignore::urllib3.exceptions.InsecureRequestWarning")
-def test_jupyterhub_loads_roles_from_keycloak(api_token):
-    response = requests.get(
+def test_jupyterhub_loads_roles_from_keycloak():
+    session = get_jupyterhub_session()
+    xsrf_token = session.cookies.get("_xsrf")
+    response = session.get(
         f"https://{constants.NEBARI_HOSTNAME}/hub/api/users",
-        headers={"Authorization": f"Bearer {api_token}"},
+        headers={"X-XSRFToken": xsrf_token},
         verify=False,
     )
     users = response.json()

--- a/tests/tests_deployment/test_jupyterhub_api.py
+++ b/tests/tests_deployment/test_jupyterhub_api.py
@@ -13,9 +13,10 @@ def api_token():
 @pytest.mark.filterwarnings("ignore::urllib3.exceptions.InsecureRequestWarning")
 def test_jupyterhub_loads_roles_from_keycloak(api_token):
     response = requests.get(
-        f"https://{constants.NEBARI_HOSTNAME}/hub/api/user/{constants.KEYCLOAK_USERNAME}",
+        f"https://{constants.NEBARI_HOSTNAME}/hub/api/users",
         headers={"Authorization": f"Bearer {api_token}"},
         verify=False,
     )
-    user = response.json()
-    assert user["roles"] == []
+    users = response.json()
+    print(users)
+    assert users[0]["roles"] == []

--- a/tests/tests_deployment/test_jupyterhub_api.py
+++ b/tests/tests_deployment/test_jupyterhub_api.py
@@ -1,0 +1,21 @@
+import pytest
+import requests
+
+from tests.tests_deployment import constants
+from tests.tests_deployment.utils import get_jupyterhub_token
+
+
+@pytest.fixture(scope="session")
+def api_token():
+    return get_jupyterhub_token("jupyterhub-api")
+
+
+@pytest.mark.filterwarnings("ignore::urllib3.exceptions.InsecureRequestWarning")
+def test_jupyterhub_loads_roles_from_keycloak(api_token):
+    response = requests.get(
+        f"https://{constants.NEBARI_HOSTNAME}/hub/api/user/{constants.KEYCLOAK_USERNAME}",
+        headers={"Authorization": f"Bearer {api_token}"},
+        verify=False,
+    )
+    user = response.json()
+    assert user["roles"] == []


### PR DESCRIPTION
## Reference Issues or PRs

Closes #2308

It is useful to think about this PR as having two parts:
- (a) when user logs in (or their cookie gets refreshed), we extract the roles list from the auth data to ensure that their roles are up to date (which is handled by JupyterHub)
- (b) when restarting JupyterHub we load all the roles and role assignments from Keycloak using Keycloak REST API; this is to prevent users from being stripped from role assignments because auth-managed roles are not meant to be persisted indefinitely in JupyterHub (by definition). Note, that we _could_ decide not to strip the roles at all, but then if an administrator accidentally grants an elevated role to a user in Keycloak, the user would retain such a role forever (until manually modified in JupyterHub database).

## What does this implement/fix?

_Put a `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds a feature)
- [ ] Breaking change (fix or feature that would cause existing features not to work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Other (please describe):

## Testing

- [ ] Did you test the pull request locally?
- [x] Did you add new tests? I will be developing with the feedback loop of the upstream CI because of https://github.com/nebari-dev/nebari/issues/2446. Sorry about the spam each time I push.

## Any other comments?

This PR includes https://github.com/nebari-dev/nebari/pull/2427 for now, but ideally https://github.com/nebari-dev/nebari/pull/2427 would be merged first.

As of this PR the roles have no scopes. There are a few ways to associate the roles with a scope, one is having a key-value map, another is encoding the scope specification in the role name or description; this is tracked in https://github.com/nebari-dev/nebari/issues/2432.