### PR TITLE
Remove VSCode from jhub_apps default services

### DIFF
--- a/src/_nebari/stages/kubernetes_services/template/modules/kubernetes/services/jupyterhub/files/jupyterhub/02-spawner.py
+++ b/src/_nebari/stages/kubernetes_services/template/modules/kubernetes/services/jupyterhub/files/jupyterhub/02-spawner.py
@@ -80,7 +80,6 @@ if z2jh.get_config("custom.jhub-apps-enabled"):
             service_for_jhub_apps(name="Users", url="/auth/admin/nebari/console/"),
             service_for_jhub_apps(name="Environments", url="/conda-store"),
             service_for_jhub_apps(name="Monitoring", url="/monitoring"),
-            service_for_jhub_apps(name="VSCode", url="/user/[USER]/vscode"),
         ]
     )
 


### PR DESCRIPTION
VSCode is now added by default to the new JHub Apps/App Launcher side navigation. This update, in addition to Nebari providing a default list of services for jhub_apps (which includes VSCode), is causing a duplicate entry in the side navigation.

This PR removes VSCode from the default jub_apps configuration as it is not needed anymore and resolves the duplicate entry.

## Reference Issues or PRs

N/A

## What does this implement/fix?

_Put a `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds a feature)
- [ ] Breaking change (fix or feature that would cause existing features not to work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Other (please describe):

## Testing

- [ ] Did you test the pull request locally?
- [ ] Did you add new tests?

## Any other comments?

<!--
Please be aware that we are a loose team of volunteers, so patience is necessary;
assistance handling other issues is very welcome.
We value all user contributions. If we are slow to review, either the pull request needs some benchmarking, tinkering,
convincing, etc., or the reviewers are likely busy. In either case,
we ask for your understanding during the
review process.
Thanks for contributing to Nebari 🙏🏼!
-->
