### PR TITLE
remove dns sleep

### DIFF
--- a/src/_nebari/stages/kubernetes_ingress/__init__.py
+++ b/src/_nebari/stages/kubernetes_ingress/__init__.py
@@ -93,17 +93,18 @@ def check_ingress_dns(stage_outputs: Dict[str, Dict[str, Any]], disable_prompt: 
 
     attempt = 0
     while not _attempt_dns_lookup(domain_name, ip):
-        sleeptime = 60 * (2**attempt)
-        if not disable_prompt:
+        if disable_prompt:
+            sleeptime = 60 * (2**attempt)
+            print(f"Will attempt to poll DNS again in {sleeptime} seconds...")
+            time.sleep(sleeptime)
+        else:
             input(
                 f"After attempting to poll the DNS, the record for domain={domain_name} appears not to exist, "
                 f"has recently been updated, or has yet to fully propagate. This non-deterministic behavior is likely due to "
-                f"DNS caching and will likely resolve itself in a few minutes.\n\n\tTo poll the DNS again in {sleeptime} seconds "
-                f"[Press Enter].\n\n...otherwise kill the process and run the deployment again later..."
+                f"DNS caching and will likely resolve itself in a few minutes.\n\n\tTo poll the DNS again [Press Enter].\n\n"
+                f"...otherwise kill the process and run the deployment again later..."
             )
 
-        print(f"Will attempt to poll DNS again in {sleeptime} seconds...")
-        time.sleep(sleeptime)
         attempt += 1
         if attempt == 5:
             print(


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://nebari.dev/community
-->

## Reference Issues or PRs
There is no need for a sleep on trying DNS lookup unless you've disabled the prompt since it waits til you press Enter anyways.  This removes the sleep the case you haven't disabled prompts.

<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create a link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

## What does this implement/fix?

_Put a `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds a feature)
- [ ] Breaking change (fix or feature that would cause existing features not to work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Other (please describe):

## Testing

- [ ] Did you test the pull request locally?
- [ ] Did you add new tests?

## Any other comments?

<!--
Please be aware that we are a loose team of volunteers, so patience is necessary;
assistance handling other issues is very welcome.
We value all user contributions. If we are slow to review, either the pull request needs some benchmarking, tinkering,
convincing, etc., or the reviewers are likely busy. In either case,
we ask for your understanding during the
review process.
Thanks for contributing to Nebari 🙏🏼!
-->
