### PR TITLE
Fix: KeyValueDict error when deploying to existing infrastructure

### DIFF
--- a/src/_nebari/stages/infrastructure/__init__.py
+++ b/src/_nebari/stages/infrastructure/__init__.py
@@ -174,7 +174,7 @@ def _calculate_node_groups(config: schema.Main):
             for group in ["general", "user", "worker"]
         }
     elif config.provider == schema.ProviderEnum.existing:
-        return config.existing.node_selectors
+        return config.existing.dict()["node_selectors"]
     else:
         return config.local.model_dump()["node_selectors"]
 

--- a/src/_nebari/stages/infrastructure/__init__.py
+++ b/src/_nebari/stages/infrastructure/__init__.py
@@ -174,7 +174,7 @@ def _calculate_node_groups(config: schema.Main):
             for group in ["general", "user", "worker"]
         }
     elif config.provider == schema.ProviderEnum.existing:
-        return config.existing.dict()["node_selectors"]
+        return config.existing.model_dump()["node_selectors"]
     else:
         return config.local.model_dump()["node_selectors"]
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://nebari.dev/community
-->

## Reference Issues or PRs
Fixes #2128 
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create a link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

## What does this implement/fix?

_Put a `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds a feature)
- [ ] Breaking change (fix or feature that would cause existing features not to work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Other (please describe):

## Testing

- [x] Did you test the pull request locally?
- [ ] Did you add new tests? N/A

## Any other comments?
Ran into this bug again when trying to update our deploymen to 24.6.1, I guess we are one of the few deploying to "existing" infrastructure. Then after an hour of troubleshooting learned that I already had created a bug report for this. Here is the PR to hopefully have it fixed in the newer versions!

<!--
Please be aware that we are a loose team of volunteers, so patience is necessary;
assistance handling other issues is very welcome.
We value all user contributions. If we are slow to review, either the pull request needs some benchmarking, tinkering,
convincing, etc., or the reviewers are likely busy. In either case,
we ask for your understanding during the
review process.
Thanks for contributing to Nebari 🙏🏼!
-->
