### PR TITLE
ENH 2451: skip conditionals

### DIFF
--- a/.github/workflows/test_aws_integration.yaml
+++ b/.github/workflows/test_aws_integration.yaml
@@ -33,11 +33,34 @@ env:
   NEBARI_GH_BRANCH: ${{ github.event.inputs.branch || 'develop' }}
   NEBARI_IMAGE_TAG: ${{ github.event.inputs.image-tag || 'main' }}
   TF_LOG: ${{ github.event.inputs.tf-log-level || 'info' }}
-
+  NO_PROVIDER_CREDENTIALS_aws: false
+  
 
 jobs:
+  check-for-credentials_aws:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+
+    outputs:
+      provider_credentials_aws: ${{ steps.flag-check.outputs.provider_credentials_aws }}
+    
+    steps:
+
+      - name: Check if user wants to run AWS integration based on credentials
+        id: flag-check
+        run: |
+          if [ "${{ env.NO_PROVIDER_CREDENTIALS_aws }}" == "true" ]; then
+            echo "::set-output name=provider_credentials_aws::0"
+          else
+            echo "::set-output name=provider_credentials_aws::1"
+          fi        
+    
   test-aws-integration:
     runs-on: ubuntu-latest
+    needs: check-for-credentials_aws
+    if: ${{ needs.check-for-credentials.outputs.provider_credentials_aws == '1' }}
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/test_aws_integration.yaml
+++ b/.github/workflows/test_aws_integration.yaml
@@ -34,7 +34,6 @@ env:
   NEBARI_IMAGE_TAG: ${{ github.event.inputs.image-tag || 'main' }}
   TF_LOG: ${{ github.event.inputs.tf-log-level || 'info' }}
   NO_PROVIDER_CREDENTIALS_aws: false
-  
 
 jobs:
   check-for-credentials_aws:
@@ -42,12 +41,9 @@ jobs:
     permissions:
       id-token: write
       contents: read
-
     outputs:
       provider_credentials_aws: ${{ steps.flag-check.outputs.provider_credentials_aws }}
-    
     steps:
-
       - name: Check if user wants to run AWS integration based on credentials
         id: flag-check
         run: |
@@ -55,8 +51,8 @@ jobs:
             echo "::set-output name=provider_credentials_aws::0"
           else
             echo "::set-output name=provider_credentials_aws::1"
-          fi        
-    
+          fi
+          
   test-aws-integration:
     runs-on: ubuntu-latest
     needs: check-for-credentials_aws

--- a/.github/workflows/test_azure_integration.yaml
+++ b/.github/workflows/test_azure_integration.yaml
@@ -31,10 +31,33 @@ env:
   NEBARI_GH_BRANCH: ${{ github.event.inputs.branch || 'develop' }}
   NEBARI_IMAGE_TAG: ${{ github.event.inputs.image-tag || 'main' }}
   TF_LOG: ${{ github.event.inputs.tf-log-level || 'info' }}
+  NO_PROVIDER_CREDENTIALS_azure: false
 
 jobs:
+  check-for-credentials:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+
+    outputs:
+      provider_credentials: ${{ steps.flag-check.outputs.provider_credentials_azure }}
+    
+    steps:
+
+      - name: Check if user wants to run Azure integration based on credentials
+        id: flag-check
+        run: |
+          if [ "${{ env.NO_PROVIDER_CREDENTIALS_azure }}" == "true" ]; then
+            echo "::set-output name=provider_credentials_azure::0"
+          else
+            echo "::set-output name=provider_credentials_azure::1"
+          fi        
+          
   test-azure-integration:
     runs-on: ubuntu-latest
+    needs: check-for-credentials
+    if: ${{ needs.check-for-credentials.outputs.provider_credentials_azure == '1' }}
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/test_azure_integration.yaml
+++ b/.github/workflows/test_azure_integration.yaml
@@ -41,7 +41,7 @@ jobs:
       contents: read
 
     outputs:
-      provider_credentials: ${{ steps.flag-check.outputs.provider_credentials_azure }}
+      provider_credentials_azure: ${{ steps.flag-check.outputs.provider_credentials_azure }}
     
     steps:
 

--- a/.github/workflows/test_azure_integration.yaml
+++ b/.github/workflows/test_azure_integration.yaml
@@ -52,7 +52,7 @@ jobs:
             echo "::set-output name=provider_credentials_azure::0"
           else
             echo "::set-output name=provider_credentials_azure::1"
-          fi        
+          fi
           
   test-azure-integration:
     runs-on: ubuntu-latest

--- a/.github/workflows/test_do_integration.yaml
+++ b/.github/workflows/test_do_integration.yaml
@@ -35,18 +35,14 @@ env:
 
 
 jobs:
-
   check-for-credentials:
     runs-on: ubuntu-latest
     permissions:
       id-token: write
       contents: read
-
     outputs:
       provider_credentials_do: ${{ steps.flag-check.outputs.provider_credentials_do }}
-    
     steps:
-
       - name: Check if user wants to run Digital Ocean integration based on credentials
         id: flag-check
         run: |
@@ -54,7 +50,7 @@ jobs:
             echo "::set-output name=provider_credentials_do::0"
           else
             echo "::set-output name=provider_credentials_do::1"
-          fi      
+          fi
 
           
   test-do-integration:

--- a/.github/workflows/test_do_integration.yaml
+++ b/.github/workflows/test_do_integration.yaml
@@ -31,11 +31,36 @@ env:
   NEBARI_GH_BRANCH: ${{ github.event.inputs.branch || 'develop' }}
   NEBARI_IMAGE_TAG: ${{ github.event.inputs.image-tag || 'main' }}
   TF_LOG: ${{ github.event.inputs.tf-log-level || 'info' }}
+  NO_PROVIDER_CREDENTIALS_do: false
 
 
 jobs:
+
+  check-for-credentials:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+
+    outputs:
+      provider_credentials_do: ${{ steps.flag-check.outputs.provider_credentials_do }}
+    
+    steps:
+
+      - name: Check if user wants to run Digital Ocean integration based on credentials
+        id: flag-check
+        run: |
+          if [ "${{ env.NO_PROVIDER_CREDENTIALS_do }}" == "true" ]; then
+            echo "::set-output name=provider_credentials_do::0"
+          else
+            echo "::set-output name=provider_credentials_do::1"
+          fi      
+
+          
   test-do-integration:
     runs-on: ubuntu-latest
+    needs: check-for-credentials
+    if: ${{ needs.check-for-credentials.outputs.provider_credentials_do == '1' }}
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/test_gcp_integration.yaml
+++ b/.github/workflows/test_gcp_integration.yaml
@@ -31,11 +31,35 @@ env:
   NEBARI_GH_BRANCH: ${{ github.event.inputs.branch || 'develop' }}
   NEBARI_IMAGE_TAG: ${{ github.event.inputs.image-tag || 'main' }}
   TF_LOG: ${{ github.event.inputs.tf-log-level || 'info' }}
+  NO_PROVIDER_CREDENTIALS_gcp: false
 
 
 jobs:
+  check-for-credentials:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+
+    outputs:
+      provider_credentials_gcp: ${{ steps.flag-check.outputs.provider_credentials_gcp }}
+    
+    steps:
+
+      - name: Check if user wants to run GCP integration based on credentials
+        id: flag-check
+        run: |
+          if [ "${{ env.NO_PROVIDER_CREDENTIALS_gcp }}" == "true" ]; then
+            echo "::set-output name=provider_credentials_gcp::0"
+          else
+            echo "::set-output name=provider_credentials_gcp::1"
+          fi        
+
+          
   test-gcp-integration:
     runs-on: ubuntu-latest
+    needs: check-for-credentials
+    if: ${{ needs.check-for-credentials.outputs.provider_credentials_gcp == '1' }}
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/test_gcp_integration.yaml
+++ b/.github/workflows/test_gcp_integration.yaml
@@ -33,19 +33,15 @@ env:
   TF_LOG: ${{ github.event.inputs.tf-log-level || 'info' }}
   NO_PROVIDER_CREDENTIALS_gcp: false
 
-
 jobs:
   check-for-credentials:
     runs-on: ubuntu-latest
     permissions:
       id-token: write
       contents: read
-
     outputs:
       provider_credentials_gcp: ${{ steps.flag-check.outputs.provider_credentials_gcp }}
-    
     steps:
-
       - name: Check if user wants to run GCP integration based on credentials
         id: flag-check
         run: |
@@ -53,9 +49,8 @@ jobs:
             echo "::set-output name=provider_credentials_gcp::0"
           else
             echo "::set-output name=provider_credentials_gcp::1"
-          fi        
-
-          
+          fi
+  
   test-gcp-integration:
     runs-on: ubuntu-latest
     needs: check-for-credentials


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://nebari.dev/community
-->

## Reference Issues or PRs

<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create a link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

## What does this implement/fix?

_Put a `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds a feature)
- [ ] Breaking change (fix or feature that would cause existing features not to work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Other (please describe):

## Testing

- [ ] Did you test the pull request locally?
- [ ] Did you add new tests?

## Any other comments?

This PR is related to the issue stated in ENH #2451:  https://github.com/nebari-dev/nebari/issues/2451

I have added a job to the integration test related github actions. This job acts as a mediary for a boolean environment variable and a conditional statement added to integration test job at it's top level. This was made so that a user with a fork of nebari who do not have access to the credentials for the cloud resources the job needs. 

This method was chosen for the following reasons:

* In testing, booleans on the step level did not prevent a failing of attempting to access the credentials.
* In testing, environment variables could not be used to do a boolean on the job at large.
* A flag that was not branch specific was requested by a few users (not stated in ticket) and this solution could provide this.
* This avoids adding "push:" statements to the YAML (as opposed to using ignore-branches) which will keep the workflow inherently manual or on a cron job as dictated thus far.

<!--
Please be aware that we are a loose team of volunteers, so patience is necessary;
assistance handling other issues is very welcome.
We value all user contributions. If we are slow to review, either the pull request needs some benchmarking, tinkering,
convincing, etc., or the reviewers are likely busy. In either case,
we ask for your understanding during the
review process.
Thanks for contributing to Nebari 🙏🏼!
-->
