### PR TITLE
Include deprecation notes for init/deploy subcommands

### DIFF
--- a/src/_nebari/subcommands/deploy.py
+++ b/src/_nebari/subcommands/deploy.py
@@ -84,6 +84,11 @@ def nebari_subcommand(cli: typer.Typer):
                     stages.remove(stage)
             rich.print("Skipping remote state provision")
 
+        # Digital Ocean support deprecation warning -- Nebari 2024.7.1
+        if config.get("provider", "") == "do" and not disable_prompt:
+            msg = "Digital Ocean support is currently being deprecated and will be removed in a future release. Would you like to continue? [y/N]"
+            typer.confirm(msg)
+
         deploy_configuration(
             config,
             stages,

--- a/src/_nebari/subcommands/deploy.py
+++ b/src/_nebari/subcommands/deploy.py
@@ -86,7 +86,7 @@ def nebari_subcommand(cli: typer.Typer):
 
         # Digital Ocean support deprecation warning -- Nebari 2024.7.1
         if config.provider == "do" and not disable_prompt:
-            msg = "Digital Ocean support is currently being deprecated and will be removed in a future release. Would you like to continue? [y/N]"
+            msg = "Digital Ocean support is currently being deprecated and will be removed in a future release. Would you like to continue?"
             typer.confirm(msg)
 
         deploy_configuration(

--- a/src/_nebari/subcommands/deploy.py
+++ b/src/_nebari/subcommands/deploy.py
@@ -85,7 +85,7 @@ def nebari_subcommand(cli: typer.Typer):
             rich.print("Skipping remote state provision")
 
         # Digital Ocean support deprecation warning -- Nebari 2024.7.1
-        if config.get("provider", "") == "do" and not disable_prompt:
+        if config.provider == "do" and not disable_prompt:
             msg = "Digital Ocean support is currently being deprecated and will be removed in a future release. Would you like to continue? [y/N]"
             typer.confirm(msg)
 

--- a/src/_nebari/subcommands/init.py
+++ b/src/_nebari/subcommands/init.py
@@ -662,6 +662,7 @@ def guided_init_wizard(ctx: typer.Context, guided_init: str):
                 "\n\t❗️ [purple]local[/purple] requires Docker and Kubernetes running on your local machine. "
                 "[italic]Currently only available on Linux OS.[/italic]"
                 "\n\t❗️ [purple]existing[/purple] refers to an existing Kubernetes cluster that Nebari can be deployed on.\n"
+                "\n\t❗️ [red]Digital Ocean[/red] is currently being deprecated and support will be removed in the future.\n"
             )
         )
         # try:

--- a/src/_nebari/subcommands/init.py
+++ b/src/_nebari/subcommands/init.py
@@ -595,6 +595,13 @@ def nebari_subcommand(cli: typer.Typer):
         inputs.cloud_provider = check_cloud_provider_creds(
             cloud_provider, disable_prompt
         )
+
+        # Digital Ocean deprecation warning -- Nebari 2024.7.1
+        if inputs.cloud_provider == ProviderEnum.do.value.lower():
+            rich.print(
+                ":warning: Digital Ocean support is being deprecated and support will be removed in the future. :warning:\n"
+            )
+
         inputs.region = check_cloud_provider_region(region, inputs.cloud_provider)
         inputs.kubernetes_version = check_cloud_provider_kubernetes_version(
             kubernetes_version, inputs.cloud_provider, inputs.region


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://nebari.dev/community
-->

## Reference Issues or PRs

closes #2565

<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create a link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

## What does this implement/fix?

- Adds a new message while selecting the available options during `guided-init` to inform the user that Digital Ocean (DO) support is being deprecated.
- Includes a confirmation message when deploying clusters of DO, warning of the deprecation

_Put a `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds a feature)
- [ ] Breaking change (fix or feature that would cause existing features not to work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Other (please describe):

## Testing

- [ ] Did you test the pull request locally?
- [ ] Did you add new tests?

## Any other comments?

<!--
Please be aware that we are a loose team of volunteers, so patience is necessary;
assistance handling other issues is very welcome.
We value all user contributions. If we are slow to review, either the pull request needs some benchmarking, tinkering,
convincing, etc., or the reviewers are likely busy. In either case,
we ask for your understanding during the
review process.
Thanks for contributing to Nebari 🙏🏼!
-->
