### PR TITLE
Improve codespell support: adjust and concentrate config to pyproject.toml and fix more typos

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -53,6 +53,8 @@ repos:
             "--write",
           ]
         language: python
+        additional_dependencies:
+        - tomli
 
   # python
   - repo: https://github.com/psf/black

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -186,7 +186,7 @@ default.check-filename = false  # Turn off initially, enable once https://github
 
 [tool.codespell]
 # Ref: https://github.com/codespell-project/codespell#using-a-config-file
-skip = '_build,*/build/*,*/node_modules/*,nebari.egg-info,*.git,*.js,package-lock.json,*.yaml,*.yml,*.lock'
+skip = '_build,*/build/*,*/node_modules/*,nebari.egg-info,*.git,package-lock.json,*.lock'
 check-hidden = true
 ignore-regex = '^\s*"image/\S+": ".*'
 ignore-words-list = 'aks'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -186,7 +186,7 @@ default.check-filename = false  # Turn off initially, enable once https://github
 
 [tool.codespell]
 # Ref: https://github.com/codespell-project/codespell#using-a-config-file
-skip = '.git*,package-lock.json,*.lock'
+skip = '_build,*/build/*,*/node_modules/*,nebari.egg-info,*.git,*.js,package-lock.json,*.yaml,*.yml,*.lock'
 check-hidden = true
 ignore-regex = '^\s*"image/\S+": ".*'
-# ignore-words-list = ''
+ignore-words-list = 'aks'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -183,3 +183,10 @@ files.extend-exclude = ["_build", "*/build/*", "*/node_modules/*", "nebari.egg-i
 default.extend-ignore-re = ["(?Rm)^.*(#|//)\\s*typos: ignore$"]
 default.extend-ignore-words-re = ["aks", "AKS"]
 default.check-filename = false  # Turn off initially, enable once https://github.com/nebari-dev/nebari/issues/2598 is addressed
+
+[tool.codespell]
+# Ref: https://github.com/codespell-project/codespell#using-a-config-file
+skip = '.git*,package-lock.json,*.lock'
+check-hidden = true
+ignore-regex = '^\s*"image/\S+": ".*'
+# ignore-words-list = ''

--- a/src/_nebari/stages/kubernetes_services/template/modules/kubernetes/services/monitoring/dashboards/Main/conda_store.json
+++ b/src/_nebari/stages/kubernetes_services/template/modules/kubernetes/services/monitoring/dashboards/Main/conda_store.json
@@ -357,7 +357,7 @@
           "refId": "A"
         }
       ],
-      "title": "Buliding",
+      "title": "Building",
       "type": "stat"
     },
     {

--- a/src/_nebari/stages/kubernetes_services/template/modules/kubernetes/services/monitoring/dashboards/Main/keycloak.json
+++ b/src/_nebari/stages/kubernetes_services/template/modules/kubernetes/services/monitoring/dashboards/Main/keycloak.json
@@ -403,7 +403,7 @@
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
-          "legendFormat": "Comitted",
+          "legendFormat": "Committed",
           "refId": "C"
         },
         {


### PR DESCRIPTION
- Concentrates codespell configuration in pyproject.toml instead of pre-commit configuration so user could simply run `codespell` and get it all clean
- Do codespell .json files (but not package-lock.json)
- Two typos fixed 
- Highly related: https://github.com/nebari-dev/nebari/pull/2568 . Apparently more typos to add to codespell ;-)

TODOs:
- [x] Check if CI workflow is actually needed -- may be pre-commit would pick up typo in that TEMP commit. pre-commit fixes it, so no CI to just detect typos is needed per se (well, pre-commit runs on changed only files AFAIK, with upgrade of codespell in pre-commit might require a run on all files... probably nothing new in procedures)

