### PR TITLE
Allow to run jupyter-gallery server in a sidecar container

### DIFF
--- a/src/_nebari/stages/kubernetes_services/__init__.py
+++ b/src/_nebari/stages/kubernetes_services/__init__.py
@@ -252,6 +252,7 @@ class JupyterLabGallerySettings(schema.Base):
     destination: str = "examples"
     exhibits: List[JupyterLabGalleryExhibit] = []
     hide_gallery_without_exhibits: bool = True
+    run_in_separate_container: bool = False
 
 
 class JupyterLab(schema.Base):

--- a/src/_nebari/stages/kubernetes_services/template/jupyterhub.tf
+++ b/src/_nebari/stages/kubernetes_services/template/jupyterhub.tf
@@ -71,6 +71,8 @@ variable "jupyterlab-gallery-settings" {
       branch      = optional(string)
       depth       = optional(number)
     }))
+
+    run_in_separate_container = optional(bool)
   })
 }
 
@@ -169,7 +171,9 @@ module "jupyterhub" {
 
   jupyterlab-default-settings = var.jupyterlab-default-settings
 
-  jupyterlab-gallery-settings = var.jupyterlab-gallery-settings
+  jupyterlab-gallery-settings        = { for k, v in var.jupyterlab-gallery-settings : k => v if k != "run_in_separate_container" }
+  jupyterlab-gallery-sidecar-enabled = var.jupyterlab-gallery-settings.run_in_separate_container
+  jupyterlab-gallery-sidecar-port    = 9989
 
   jupyterlab-pioneer-enabled    = var.jupyterlab-pioneer-enabled
   jupyterlab-pioneer-log-format = var.jupyterlab-pioneer-log-format

--- a/src/_nebari/stages/kubernetes_services/template/modules/kubernetes/services/jupyterhub/middleware.tf
+++ b/src/_nebari/stages/kubernetes_services/template/modules/kubernetes/services/jupyterhub/middleware.tf
@@ -31,3 +31,20 @@ resource "kubernetes_manifest" "jupyterhub-proxy-add-slash" {
     }
   }
 }
+
+resource "kubernetes_manifest" "jupyterhub-proxy-jupyter-gallery" {
+  manifest = {
+    apiVersion = "traefik.containo.us/v1alpha1"
+    kind       = "Middleware"
+    metadata = {
+      name      = "nebari-jupyterhub-proxy-jupyter-gallery"
+      namespace = var.namespace
+    }
+    spec = {
+      replacePathRegex = {
+        regex       = "^/user/([^/]+)/jupyterlab-gallery(/?[^/]+)$"
+        replacement = "/user/$${1}/proxy/${var.jupyterlab-gallery-sidecar-port}/jupyterlab-gallery$${2}"
+      }
+    }
+  }
+}

--- a/src/_nebari/stages/kubernetes_services/template/modules/kubernetes/services/jupyterhub/variables.tf
+++ b/src/_nebari/stages/kubernetes_services/template/modules/kubernetes/services/jupyterhub/variables.tf
@@ -183,6 +183,16 @@ variable "jupyterlab-gallery-settings" {
   })
 }
 
+variable "jupyterlab-gallery-sidecar-enabled" {
+  description = "Whether to run jupyterlab-gallery in a sidecar container"
+  type        = bool
+}
+
+variable "jupyterlab-gallery-sidecar-port" {
+  description = "Port for jupyterlab-gallery sidecar container"
+  type        = number
+}
+
 variable "jupyterlab-pioneer-enabled" {
   description = "Enable JupyterLab Pioneer for telemetry"
   type        = bool

--- a/tests/tests_unit/cli_validate/min.happy.jupyterlab.gallery_settings.yaml
+++ b/tests/tests_unit/cli_validate/min.happy.jupyterlab.gallery_settings.yaml
@@ -8,3 +8,4 @@ jupyterlab:
         git: https://github.com/nebari-dev/nebari.git
         homepage: https://github.com/nebari-dev/nebari
         description: 🪴 Nebari - your open source data science platform
+    run_in_separate_container: true


### PR DESCRIPTION
## Reference Issues or PRs

Closes #2514 - this is the proposed solution (a)

## What does this implement/fix?

_Put a `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds a feature)
- [ ] Breaking change (fix or feature that would cause existing features not to work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Other (please describe):

## Testing

- [x] Did you test the pull request locally?
- [ ] Did you add new tests?

## Any other comments?

To test this feature:
1. Shut down your Jupyter server
2. Deploy with the following config in your `nebari-config.yaml`:
    ```yaml
    jupyterlab:
      gallery_settings:
        title: Example repositories
        destination: examples
        run_in_separate_container: true
        exhibits:
        - title: Nebari
          git: https://github.com/nebari-dev/nebari.git
          homepage: https://github.com/nebari-dev/nebari
          description: 🪴 Nebari - your open source data science platform
    default_images:
      jupyterlab: quay.io/nebari/nebari-jupyterlab:jupyterlab-gallery-v0.5.0-72d14e3-20240727
    ```
3. Open a notebook/terminal and execute `ls /etc/jupyter`
4. See that `jupyyter_gallery_config.json` is no longer present (when `run_in_separate_container` is set to `true`)

## Still to be done
- [ ] update docker image `main` branch (unless we want a dedicated, smaller docker image):
    - [ ] with a new version of `jupyter-server-proxy` one the PR with SSE streaming support is merged
    - [ ] with a new version of jupyterhub once the PR patching `**kwargs` handling in `initalize` is merged
    - [ ] remove the monkeypatch for the latter from this PR once we can
- [ ] implement (and test) fallback volume mounting for `run_in_separate_container=false`
- [ ] open a documentation PR against nebari docs
- [ ] add resource limits for the container
- [ ] rename variables and functions
    - [ ] `preserve_extra_files` is too technical, and now it does more than that; 
    - [ ] `etc-jupyter-secret-config-data` is correct if we want to treat more config files like that; but then we probably would want to use a more generic name for this container (currently "gallery-sidecar")
    - [ ] `run_in_separate_container` - this is the admin-facing config option; other ideas welcome, e.g. `isolate_runtime_and_config`
- [ ] reconsider if we can re-enable xsrf token validation (I will write down a separate comment on this one later)