### PR TITLE
Add `depends_on` for bucket encryption

### DIFF
--- a/src/_nebari/stages/infrastructure/template/aws/modules/s3/main.tf
+++ b/src/_nebari/stages/infrastructure/template/aws/modules/s3/main.tf
@@ -35,6 +35,6 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "main" {
     }
   }
   // AWS may return HTTP 409 if PutBucketEncryption is called immediately after S3
-  // bucket creation. Adding dependency avoids concurent requests.
+  // bucket creation. Adding dependency avoids concurrent requests.
   depends_on = [aws_s3_bucket_public_access_block.main]
 }

--- a/src/_nebari/stages/infrastructure/template/aws/modules/s3/main.tf
+++ b/src/_nebari/stages/infrastructure/template/aws/modules/s3/main.tf
@@ -17,6 +17,14 @@ resource "aws_s3_bucket" "main" {
   }, var.tags)
 }
 
+resource "aws_s3_bucket_public_access_block" "main" {
+  bucket                  = aws_s3_bucket.main.id
+  ignore_public_acls      = true
+  block_public_acls       = true
+  block_public_policy     = true
+  restrict_public_buckets = true
+}
+
 resource "aws_s3_bucket_server_side_encryption_configuration" "main" {
   bucket = aws_s3_bucket.main.id
 
@@ -26,12 +34,7 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "main" {
       sse_algorithm     = "aws:kms"
     }
   }
-}
-
-resource "aws_s3_bucket_public_access_block" "main" {
-  bucket                  = aws_s3_bucket.main.id
-  ignore_public_acls      = true
-  block_public_acls       = true
-  block_public_policy     = true
-  restrict_public_buckets = true
+  // AWS may return HTTP 409 if PutBucketEncryption is called immediately after S3
+  // bucket creation. Adding dependency avoids concurent requests.
+  depends_on = [aws_s3_bucket_public_access_block.main]
 }

--- a/src/_nebari/stages/terraform_state/template/aws/modules/terraform-state/main.tf
+++ b/src/_nebari/stages/terraform_state/template/aws/modules/terraform-state/main.tf
@@ -20,6 +20,14 @@ resource "aws_s3_bucket" "terraform-state" {
   }
 }
 
+resource "aws_s3_bucket_public_access_block" "terraform-state" {
+  bucket                  = aws_s3_bucket.terraform-state.id
+  ignore_public_acls      = true
+  block_public_acls       = true
+  block_public_policy     = true
+  restrict_public_buckets = true
+}
+
 resource "aws_s3_bucket_server_side_encryption_configuration" "terraform-state" {
   bucket = aws_s3_bucket.terraform-state.id
 
@@ -29,14 +37,9 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "terraform-state" 
       sse_algorithm     = "aws:kms"
     }
   }
-}
-
-resource "aws_s3_bucket_public_access_block" "terraform-state" {
-  bucket                  = aws_s3_bucket.terraform-state.id
-  ignore_public_acls      = true
-  block_public_acls       = true
-  block_public_policy     = true
-  restrict_public_buckets = true
+  # // AWS may return HTTP 409 if PutBucketEncryption is called immediately after S3
+  # bucket creation. Adding dependency avoids concurent requests.
+  depends_on = [aws_s3_bucket_public_access_block.terraform-state]
 }
 
 resource "aws_dynamodb_table" "terraform-state-lock" {

--- a/src/_nebari/stages/terraform_state/template/aws/modules/terraform-state/main.tf
+++ b/src/_nebari/stages/terraform_state/template/aws/modules/terraform-state/main.tf
@@ -38,7 +38,7 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "terraform-state" 
     }
   }
   # // AWS may return HTTP 409 if PutBucketEncryption is called immediately after S3
-  # bucket creation. Adding dependency avoids concurent requests.
+  # bucket creation. Adding dependency avoids concurrent requests.
   depends_on = [aws_s3_bucket_public_access_block.terraform-state]
 }
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://nebari.dev/community
-->

## Reference Issues or PRs

#2613 

<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create a link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

## What does this implement/fix?

If a PutBucketEncryption call is made to AWS to apply server-side encryption configuration just after an S3 bucket is created, AWS may return an HTTP 409 (Conflict) error with an OperationAborted error code. By making `aws_s3_bucket_server_side_encryption_configuration` explicitly dependent on `aws_s3_bucket_public_access_block`, we guarantee two things:
- The encryption will not run concurrently as it now needs to wait for the public access block to succeed;
- It will not run directly after the bucket creation, giving us enough time for the requests to correctly process.

Below, we can see a graph representing the resource dependencies; the object associated with the arrowhead has priority over the others.

Before the `depends_on` tag:
![image](https://github.com/user-attachments/assets/2ca922de-f361-47dd-983f-58b231324c42)

After the dependency was set:
![image](https://github.com/user-attachments/assets/7caa2233-f8c7-474a-9566-6137f5ca5014)

_Put a `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds a feature)
- [ ] Breaking change (fix or feature that would cause existing features not to work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Other (please describe):

## Testing

- [ ] Did you test the pull request locally?
- [ ] Did you add new tests?

## Any other comments?

<!--
Please be aware that we are a loose team of volunteers, so patience is necessary;
assistance handling other issues is very welcome.
We value all user contributions. If we are slow to review, either the pull request needs some benchmarking, tinkering,
convincing, etc., or the reviewers are likely busy. In either case,
we ask for your understanding during the
review process.
Thanks for contributing to Nebari 🙏🏼!
-->
