### PR TITLE
add a "moved" block to account for refactored terraform code without deleting/recreating NFS disks

### DIFF
--- a/src/_nebari/stages/kubernetes_services/template/conda-store.tf
+++ b/src/_nebari/stages/kubernetes_services/template/conda-store.tf
@@ -68,6 +68,12 @@ module "kubernetes-conda-store-server" {
   ]
 }
 
+moved {
+  from = module.conda-store-nfs-mount
+  to   = module.kubernetes-conda-store-server.module.conda-store-nfs-mount[0]
+}
+
+
 locals {
   conda-store-fs = var.shared_fs_type
 }

--- a/src/_nebari/stages/kubernetes_services/template/jupyterhub.tf
+++ b/src/_nebari/stages/kubernetes_services/template/jupyterhub.tf
@@ -116,6 +116,11 @@ module "kubernetes-nfs-server" {
   node-group   = var.node_groups.general
 }
 
+moved {
+  from = module.jupyterhub-nfs-mount
+  to   = module.jupyterhub-nfs-mount[0]
+}
+
 module "jupyterhub-nfs-mount" {
   count  = local.jupyterhub-fs == "nfs" ? 1 : 0
   source = "./modules/kubernetes/nfs-mount"


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://nebari.dev/community
-->

## Reference Issues or PRs
Fixes https://github.com/nebari-dev/nebari/issues/2638
Uses [moved blocks](https://developer.hashicorp.com/terraform/language/modules/develop/refactoring#enabling-count-or-for_each-for-a-resource) to account for refactored terraform code.

I've tested on the following deployments.
- [x] Local
- [x] GCP
- [x] Azure

<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create a link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

## What does this implement/fix?

_Put a `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds a feature)
- [ ] Breaking change (fix or feature that would cause existing features not to work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Other (please describe):

## Testing

- [x] Did you test the pull request locally?
- [ ] Did you add new tests?

## Any other comments?

<!--
Please be aware that we are a loose team of volunteers, so patience is necessary;
assistance handling other issues is very welcome.
We value all user contributions. If we are slow to review, either the pull request needs some benchmarking, tinkering,
convincing, etc., or the reviewers are likely busy. In either case,
we ask for your understanding during the
review process.
Thanks for contributing to Nebari 🙏🏼!
-->
