### PR TITLE
Fix converted init command in guided init

### DIFF
--- a/src/_nebari/subcommands/init.py
+++ b/src/_nebari/subcommands/init.py
@@ -934,16 +934,19 @@ def guided_init_wizard(ctx: typer.Context, guided_init: str):
             )
         )
 
-        base_cmd = f"nebari init {inputs.cloud_provider}"
+        base_cmd = f"nebari init {inputs.cloud_provider.value}"
 
         def if_used(key, model=inputs, ignore_list=["cloud_provider"]):
             if key not in ignore_list:
-                b = "--{key} {value}"
                 value = getattr(model, key)
-                if isinstance(value, str) and (value != "" or value is not None):
-                    return b.format(key=key, value=value).replace("_", "-")
-                if isinstance(value, bool) and value:
-                    return b.format(key=key, value=value).replace("_", "-")
+                if isinstance(value, enum.Enum):
+                    return f"--{key} {value.value}".replace("_", "-")
+                elif isinstance(value, bool):
+                    if value:
+                        return f"--{key}".replace("_", "-")
+                elif isinstance(value, (int, str)):
+                    if value:
+                        return f"--{key} {value}".replace("_", "-")
 
         cmds = " ".join(
             [


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://nebari.dev/community
-->

## Reference Issues or PRs
Closes #2664 

<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create a link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

## What does this implement/fix?

_Put a `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds a feature)
- [ ] Breaking change (fix or feature that would cause existing features not to work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Other (please describe):

## Testing

- [x] Did you test the pull request locally?
- [ ] Did you add new tests?

## How to test this PR?

Run `nebari init --guided-init` and answer the prompts as following:
```
        Welcome to the Guided Init wizard!

You will be asked a few questions to generate your nebari-config.yaml. For more
details, refer to the Nebari docs:

        https://nebari.dev/docs/



 🪴  Nebari runs on a Kubernetes cluster: Where do you want this Kubernetes
cluster deployed? is where you want this Kubernetes cluster deployed. For more
details, refer to the Nebari docs:

        https://nebari.dev/docs/get-started/deploy


        ❗️ local requires Docker and Kubernetes running on your local machine.
Currently only available on Linux OS.
        ❗️ existing refers to an existing Kubernetes cluster that Nebari can be
deployed on.

        ❗️ Digital Ocean is currently being deprecated and support will be
removed in the future.

   Where would you like to deploy your Nebari cluster? Local

 🪴  Next, give your Nebari instance a project name. This name is what your
Kubernetes cluster will be referred to as.

        The project name must adhere to the following requirements:
        - Letters from A to Z (upper and lower case), numbers, hyphens, and
dashes
        - Length from 3 to 16 characters
        - Begin and end with a letter


   What project name would you like to use? nebari


 🪴  Great! Now you can provide a valid domain name (i.e. the URL) to access
your Nebari instance. This should be a domain that you own. Default if
unspecified is the IP of the load balancer.


   What domain name would you like to use?


 🪴  Nebari comes with Keycloak, an open-source identity and access management
tool. This is how users and permissions are managed on the platform. To connect
Keycloak with an identity provider, you can select one now.


        ❗️ password is the default option and is not connected to any external
identity provider.

   What authentication provider would you like? password


 🪴  This next section is optional but recommended. If you wish to adopt a
GitOps approach to managing this platform, we will walk you through a set of
questions to get that setup. With this setup, Nebari will use GitHub Actions
workflows (or GitLab equivalent) to automatically handle the future deployments
of your infrastructure.


   Would you like to adopt a GitOps approach to managing Nebari? No


 🪴  This next section is optional and includes advanced configuration changes
to the Terraform state, Kubernetes Namespace and Kubernetes version.
 ⚠️  caution is advised!


   Would you like to make advanced configuration changes? No
```

You should see a properly rendered init command at the end, just like:
```
For reference, if the previous Guided Init answers were converted into a direct
nebari init command, it would be:

        nebari init local --project-name nebari --namespace dev --auth-provider
password --ci-provider none --terraform-state remote
```

<!--
If relevant, please outline the steps required to test your contribution
and the expected outcomes from the proposed changes. Providing clear
testing instructions will help reviewers evaluate your contribution.
-->

## Any other comments?

I've refactored the logic to include options passed as integers (i.e. `--explicit`) and to properly check whether values are empty. This was failing before when not passing a specific k8s version and accepting the default—the resulting command would just have an empty value for the `--kubernetes-version` resulting in a failed deployment if copied and ran.

<!--
Please be aware that we are a loose team of volunteers, so patience is necessary;
assistance handling other issues is very welcome.
We value all user contributions. If we are slow to review, either the pull request needs some benchmarking, tinkering,
convincing, etc., or the reviewers are likely busy. In either case,
we ask for your understanding during the
review process.
Thanks for contributing to Nebari 🙏🏼!
-->
