### PR TITLE
only capture stdout not stdout+stderr when capture_output=True

### DIFF
--- a/src/_nebari/provider/terraform.py
+++ b/src/_nebari/provider/terraform.py
@@ -195,6 +195,7 @@ def show(directory=None) -> dict:
                     command,
                     cwd=directory,
                     prefix="terraform",
+                    strip_errors=True,
                     capture_output=True,
                 )
             )

--- a/src/_nebari/provider/terraform.py
+++ b/src/_nebari/provider/terraform.py
@@ -194,6 +194,7 @@ def show(directory=None) -> dict:
                 run_terraform_subprocess(
                     command,
                     cwd=directory,
+                    prefix="terraform",
                     capture_output=True,
                 )
             )


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://nebari.dev/community
-->
I accidentally was trying to parse stdout + stderr as json instead of just stdout when capture_output=True.  This PR fixes that.

## Reference Issues or PRs
Fixes failing deployment tests
- e.g. https://github.com/nebari-dev/nebari/actions/runs/10658945768

I validated the idea by re-running one of them and it worked - https://github.com/nebari-dev/nebari/actions/runs/10689796315
Azure now seems to be failing for an unrelated reason - https://github.com/nebari-dev/nebari/actions/runs/10691605764
GCP redeployment - https://github.com/nebari-dev/nebari/actions/runs/10691927249

<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create a link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

## What does this implement/fix?

_Put a `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds a feature)
- [ ] Breaking change (fix or feature that would cause existing features not to work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Other (please describe):

## Testing

- [x] Did you test the pull request locally?
- [ ] Did you add new tests?

## How to test this PR?
Do a local deployment with the "TF_LOG" env var set to "TRACE"

<!--
If relevant, please outline the steps required to test your contribution
and the expected outcomes from the proposed changes. Providing clear
testing instructions will help reviewers evaluate your contribution.
-->

## Any other comments?

<!--
Please be aware that we are a loose team of volunteers, so patience is necessary;
assistance handling other issues is very welcome.
We value all user contributions. If we are slow to review, either the pull request needs some benchmarking, tinkering,
convincing, etc., or the reviewers are likely busy. In either case,
we ask for your understanding during the
review process.
Thanks for contributing to Nebari 🙏🏼!
-->
