### PR TITLE
Refactor role creation for upgrade command path

### DIFF
--- a/src/_nebari/upgrade.py
+++ b/src/_nebari/upgrade.py
@@ -1223,12 +1223,12 @@ class Upgrade_2024_9_1(UpgradeStep):
         return config
 
 
-class Upgrade_2024_10_1(UpgradeStep):
+class Upgrade_2024_11_1(UpgradeStep):
     """
-    Upgrade step for Nebari version 2024.10.1
+    Upgrade step for Nebari version 2024.11.1
     """
 
-    version = "2024.10.1"
+    version = "2024.11.1"
 
     @override
     def _version_specific_upgrade(
@@ -1319,7 +1319,7 @@ class Upgrade_2024_10_1(UpgradeStep):
                     },
                     "description": (
                         "Role to allow group directory creation, created as part of the "
-                        "Nebari 2024.10.1 upgrade workflow."
+                        "Nebari 2024.11.1 upgrade workflow."
                     ),
                 },
             )

--- a/src/_nebari/upgrade.py
+++ b/src/_nebari/upgrade.py
@@ -1214,6 +1214,22 @@ class Upgrade_2024_9_1(UpgradeStep):
 
     version = "2024.9.1"
 
+    # Nebari version 2024.9.1 has been marked as broken, and will be skipped:
+    # https://github.com/nebari-dev/nebari/issues/2798
+    @override
+    def _version_specific_upgrade(
+        self, config, start_version, config_filename: Path, *args, **kwargs
+    ):
+        return config
+
+
+class Upgrade_2024_10_1(UpgradeStep):
+    """
+    Upgrade step for Nebari version 2024.10.1
+    """
+
+    version = "2024.10.1"
+
     @override
     def _version_specific_upgrade(
         self, config, start_version, config_filename: Path, *args, **kwargs
@@ -1243,17 +1259,16 @@ class Upgrade_2024_9_1(UpgradeStep):
             Please ensure no users are currently logged in prior to deploying this
             update.
 
-            Nebari [green]2024.9.1[/green] introduces changes to how group
-            directories are mounted in JupyterLab pods.
+            This release introduces changes to how group directories are mounted in
+            JupyterLab pods.
 
             Previously, every Keycloak group in the Nebari realm automatically created a
             shared directory at ~/shared/<group-name>, accessible to all group members
             in their JupyterLab pods.
 
-            Starting with Nebari [green]2024.9.1[/green], only groups assigned the
-            JupyterHub client role [magenta]allow-group-directory-creation[/magenta] or
-            its affiliated scope [magenta]write:shared-mount[/magenta] will have their
-            directories mounted.
+            Moving forward, only groups assigned the JupyterHub client role
+            [magenta]allow-group-directory-creation[/magenta] or its affiliated scope
+            [magenta]write:shared-mount[/magenta] will have their directories mounted.
 
             By default, the admin, analyst, and developer groups will have this
             role assigned during the upgrade. For other groups, you'll now need to
@@ -1304,7 +1319,7 @@ class Upgrade_2024_9_1(UpgradeStep):
                     },
                     "description": (
                         "Role to allow group directory creation, created as part of the "
-                        "Nebari 2024.9.1 upgrade workflow."
+                        "Nebari 2024.10.1 upgrade workflow."
                     ),
                 },
             )
@@ -1345,23 +1360,6 @@ class Upgrade_2024_9_1(UpgradeStep):
                 rich.print(
                     "\n[green]All groups already have the required permissions.[/green]"
                 )
-        return config
-
-
-class Upgrade_2024_9_2(UpgradeStep):
-    """
-    Upgrade step for Nebari version 2024.9.2
-
-    """
-
-    version = "2024.9.2"
-
-    @override
-    def _version_specific_upgrade(
-        self, config, start_version, config_filename: Path, *args, **kwargs
-    ):
-        rich.print("Ready to upgrade to Nebari version [green]2024.9.2[/green].")
-
         return config
 
 

--- a/src/_nebari/upgrade.py
+++ b/src/_nebari/upgrade.py
@@ -1251,7 +1251,8 @@ class Upgrade_2024_9_1(UpgradeStep):
             in their JupyterLab pods.
 
             Starting with Nebari [green]2024.9.1[/green], only groups assigned the
-            JupyterHub client role [magenta]allow-group-directory-creation[/magenta] will have their
+            JupyterHub client role [magenta]allow-group-directory-creation[/magenta] or
+            its affiliated scope [magenta]write:shared-mount[/magenta] will have their
             directories mounted.
 
             By default, the admin, analyst, and developer groups will have this
@@ -1268,7 +1269,7 @@ class Upgrade_2024_9_1(UpgradeStep):
         # Prompt the user for role assignment (if yes, transforms the response into bool)
         assign_roles = (
             Prompt.ask(
-                "[bold]Would you like Nebari to assign the corresponding role to all of your current groups automatically?[/bold]",
+                "[bold]Would you like Nebari to assign the corresponding role/scopes to all of your current groups automatically?[/bold]",
                 choices=["y", "N"],
                 default="N",
             ).lower()
@@ -1293,15 +1294,18 @@ class Upgrade_2024_9_1(UpgradeStep):
             # Create the role if it doesn't exist
             # If the role does not exist, create it
             keycloak_admin.create_client_role(
-                client_id=client_id,
+                client_role_id=client_id,
                 skip_exists=True,
                 payload={
                     "name": role_name,
                     "attributes": {
-                        "scopes": "write:shared-mount",
-                        "component": "shared-directory" "scopes",
+                        "scopes": ["write:shared-mount"],
+                        "component": ["shared-directory"],
                     },
-                    "description": "Role to allow group directory creation, created as part of the Nebari 2024.9.1 upgrade workflow.",
+                    "description": (
+                        "Role to allow group directory creation, created as part of the "
+                        "Nebari 2024.9.1 upgrade workflow."
+                    ),
                 },
             )
 

--- a/src/_nebari/upgrade.py
+++ b/src/_nebari/upgrade.py
@@ -1306,8 +1306,7 @@ class Upgrade_2024_11_1(UpgradeStep):
             client_id = keycloak_admin.get_client_id("jupyterhub")
             role_name = "legacy-group-directory-creation-role"
 
-            # Create the role if it doesn't exist
-            # If the role does not exist, create it
+            # Create role with shared scopes
             keycloak_admin.create_client_role(
                 client_role_id=client_id,
                 skip_exists=True,


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://nebari.dev/community
-->

## Reference Issues or PRs
closes #2766 

<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create a link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

## What does this implement/fix?

This issue is a patching fix for the upgrade command present in the previous release, currently the upgrade logic when requesting the user to perform the role creation (more details see linked issue), assumes the presence of the role when assigning it to the legacy groups. However, this leads to errors when the role does not exist or is within Terraform if the user attempts to manually address the missing role to continue the upgrade.

This PRs includes a new section in the previous code logic to create the role, and to avoid conflicts with terraform, I adopted a "legacy" prefix to the role name with a befitting description for future reference when the amdins manages keycloak in the future.  

_Put a `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds a feature)
- [ ] Breaking change (fix or feature that would cause existing features not to work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Other (please describe):

## Testing

- [ ] Did you test the pull request locally?
- [ ] Did you add new tests?

## How to test this PR?

- Perform any type of deployment for Nebari `v2024.7.1`, `local` is advised, 
- create some testing groups and users with such users assigned to some of these groups (one user and one group should suffice). 
- Launch one user instance and assert the folders are mounted;
- Install this nebari version in dev mode and perform the upgrade; (You will need to create a tag  locally for proper installation of nebari)
- Assert the new role has been created in the jupyterhub client, and the previous groups all have the role assignment;
- Perform the deployment and launch a user instance to validate the folder mounting is kept the same (consider logging out first to avoid issues with caching of user_Data)

<!--
If relevant, please outline the steps required to test your contribution
and the expected outcomes from the proposed changes. Providing clear
testing instructions will help reviewers evaluate your contribution.
-->

## Any other comments?

<!--
Please be aware that we are a loose team of volunteers, so patience is necessary;
assistance handling other issues is very welcome.
We value all user contributions. If we are slow to review, either the pull request needs some benchmarking, tinkering,
convincing, etc., or the reviewers are likely busy. In either case,
we ask for your understanding during the
review process.
Thanks for contributing to Nebari 🙏🏼!
-->
