### PR TITLE
fix bug where check_immutable_fields throws error with old version of Nebari

### DIFF
--- a/src/_nebari/stages/terraform_state/__init__.py
+++ b/src/_nebari/stages/terraform_state/__init__.py
@@ -260,7 +260,7 @@ class TerraformStateStage(NebariTerraformStage):
 
         # compute diff of remote/prior and current nebari config
         nebari_config_diff = utils.JsonDiff(
-            nebari_config_state.model_dump(), self.config.model_dump()
+            nebari_config_state, self.config.model_dump()
         )
         # check if any changed fields are immutable
         for keys, old, new in nebari_config_diff.modified():
@@ -284,7 +284,7 @@ class TerraformStateStage(NebariTerraformStage):
                     f'Attempting to change immutable field "{key_path}" ("{old}"->"{new}") in Nebari config file.  Immutable fields cannot be changed after initial deployment.'
                 )
 
-    def get_nebari_config_state(self):
+    def get_nebari_config_state(self) -> dict:
         directory = str(self.output_directory / self.stage_prefix)
         tf_state = terraform.show(directory)
         nebari_config_state = None
@@ -294,11 +294,7 @@ class TerraformStateStage(NebariTerraformStage):
             tf_state.get("values", {}).get("root_module", {}).get("resources", [])
         ):
             if resource["address"] == "terraform_data.nebari_config":
-                from nebari.plugins import nebari_plugin_manager
-
-                nebari_config_state = nebari_plugin_manager.config_schema(
-                    **resource["values"]["input"]
-                )
+                nebari_config_state = resource["values"]["input"]
                 break
         return nebari_config_state
 

--- a/tests/tests_unit/test_stages.py
+++ b/tests/tests_unit/test_stages.py
@@ -29,7 +29,7 @@ def terraform_state_stage(mock_config, tmp_path):
 
 @patch.object(TerraformStateStage, "get_nebari_config_state")
 def test_check_immutable_fields_no_changes(mock_get_state, terraform_state_stage):
-    mock_get_state.return_value = terraform_state_stage.config
+    mock_get_state.return_value = terraform_state_stage.config.model_dump()
 
     # This should not raise an exception
     terraform_state_stage.check_immutable_fields()
@@ -41,7 +41,7 @@ def test_check_immutable_fields_mutable_change(
 ):
     old_config = mock_config.model_copy(deep=True)
     old_config.namespace = "old-namespace"
-    mock_get_state.return_value = old_config
+    mock_get_state.return_value = old_config.model_dump()
 
     # This should not raise an exception (namespace is mutable)
     terraform_state_stage.check_immutable_fields()
@@ -54,7 +54,7 @@ def test_check_immutable_fields_immutable_change(
 ):
     old_config = mock_config.model_copy(deep=True)
     old_config.provider = schema.ProviderEnum.gcp
-    mock_get_state.return_value = old_config
+    mock_get_state.return_value = old_config.model_dump()
 
     # Mock the provider field to be immutable
     mock_model_fields.__getitem__.return_value.json_schema_extra = {"immutable": True}
@@ -77,7 +77,7 @@ def test_check_immutable_fields_no_prior_state(mock_get_state, terraform_state_s
 def test_check_dict_value_change(mock_get_state, terraform_state_stage, mock_config):
     old_config = mock_config.model_copy(deep=True)
     terraform_state_stage.config.local.node_selectors["worker"].value += "new_value"
-    mock_get_state.return_value = old_config
+    mock_get_state.return_value = old_config.model_dump()
 
     # should not throw an exception
     terraform_state_stage.check_immutable_fields()
@@ -87,7 +87,7 @@ def test_check_dict_value_change(mock_get_state, terraform_state_stage, mock_con
 def test_check_list_change(mock_get_state, terraform_state_stage, mock_config):
     old_config = mock_config.model_copy(deep=True)
     old_config.environments["environment-dask.yaml"].channels.append("defaults")
-    mock_get_state.return_value = old_config
+    mock_get_state.return_value = old_config.model_dump()
 
     # should not throw an exception
     terraform_state_stage.check_immutable_fields()

--- a/tests/tests_unit/test_stages.py
+++ b/tests/tests_unit/test_stages.py
@@ -91,3 +91,15 @@ def test_check_list_change(mock_get_state, terraform_state_stage, mock_config):
 
     # should not throw an exception
     terraform_state_stage.check_immutable_fields()
+
+
+@patch.object(TerraformStateStage, "get_nebari_config_state")
+def test_check_immutable_fields_old_nebari_version(
+    mock_get_state, terraform_state_stage, mock_config
+):
+    old_config = mock_config.model_copy(deep=True).model_dump()
+    old_config["nebari_version"] = "2024.7.1"  # Simulate an old version
+    mock_get_state.return_value = old_config
+
+    # This should not raise an exception
+    terraform_state_stage.check_immutable_fields()


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://nebari.dev/community
-->

## Reference Issues or PRs
Fixes https://github.com/nebari-dev/nebari/issues/2781
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create a link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

## What does this implement/fix?

_Put a `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds a feature)
- [ ] Breaking change (fix or feature that would cause existing features not to work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Other (please describe):

## Testing

- [x] Did you test the pull request locally?
- [x] Did you add new tests?

## How to test this PR?

<!--
If relevant, please outline the steps required to test your contribution
and the expected outcomes from the proposed changes. Providing clear
testing instructions will help reviewers evaluate your contribution.
-->

## Any other comments?

<!--
Please be aware that we are a loose team of volunteers, so patience is necessary;
assistance handling other issues is very welcome.
We value all user contributions. If we are slow to review, either the pull request needs some benchmarking, tinkering,
convincing, etc., or the reviewers are likely busy. In either case,
we ask for your understanding during the
review process.
Thanks for contributing to Nebari 🙏🏼!
-->
