### PR TITLE
Remove explicit branch inputs from cloud integration test workflows in GHA

### DIFF
--- a/.github/workflows/test_aws_integration.yaml
+++ b/.github/workflows/test_aws_integration.yaml
@@ -25,7 +25,7 @@ on:
 
 env:
   AWS_DEFAULT_REGION: "us-west-2"
-  NEBARI_GH_BRANCH: ${{ github.event.inputs.branch || 'main' }}
+  NEBARI_IMAGE_TAG: ${{ github.event.inputs.image-tag || 'main' }}
   TF_LOG: ${{ github.event.inputs.tf-log-level || 'info' }}∏
 
 jobs:

--- a/.github/workflows/test_aws_integration.yaml
+++ b/.github/workflows/test_aws_integration.yaml
@@ -5,11 +5,6 @@ on:
     - cron: "0 0 * * MON"
   workflow_dispatch:
     inputs:
-      branch:
-        description: 'Nebari branch to deploy, test, destroy'
-        required: true
-        default: main
-        type: string
       image-tag:
         description: 'Nebari image tag created by the nebari-docker-images repo'
         required: true
@@ -31,7 +26,6 @@ on:
 env:
   AWS_DEFAULT_REGION: "us-west-2"
   NEBARI_GH_BRANCH: ${{ github.event.inputs.branch || 'main' }}
-  NEBARI_IMAGE_TAG: ${{ github.event.inputs.image-tag || 'main' }}
   TF_LOG: ${{ github.event.inputs.tf-log-level || 'info' }}∏
 
 jobs:
@@ -45,7 +39,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: ${{ env.NEBARI_GH_BRANCH }}
           fetch-depth: 0
 
       - name: Set up Python

--- a/.github/workflows/test_azure_integration.yaml
+++ b/.github/workflows/test_azure_integration.yaml
@@ -5,11 +5,6 @@ on:
     - cron: "0 0 * * MON"
   workflow_dispatch:
     inputs:
-      branch:
-        description: 'Nebari branch to deploy, test, destroy'
-        required: true
-        default: main
-        type: string
       image-tag:
         description: 'Nebari image tag created by the nebari-docker-images repo'
         required: true
@@ -28,7 +23,6 @@ on:
         - error
 
 env:
-  NEBARI_GH_BRANCH: ${{ github.event.inputs.branch || 'main' }}
   NEBARI_IMAGE_TAG: ${{ github.event.inputs.image-tag || 'main' }}
   TF_LOG: ${{ github.event.inputs.tf-log-level || 'info' }}
 
@@ -43,7 +37,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
         with:
-          ref: ${{ env.NEBARI_GH_BRANCH }}
           fetch-depth: 0
 
       - name: Set up Python

--- a/.github/workflows/test_gcp_integration.yaml
+++ b/.github/workflows/test_gcp_integration.yaml
@@ -5,11 +5,6 @@ on:
     - cron: "0 0 * * MON"
   workflow_dispatch:
     inputs:
-      branch:
-        description: 'Nebari branch to deploy, test, destroy'
-        required: true
-        default: main
-        type: string
       image-tag:
         description: 'Nebari image tag created by the nebari-docker-images repo'
         required: true
@@ -28,7 +23,6 @@ on:
         - error
 
 env:
-  NEBARI_GH_BRANCH: ${{ github.event.inputs.branch || 'main' }}
   NEBARI_IMAGE_TAG: ${{ github.event.inputs.image-tag || 'main' }}
   TF_LOG: ${{ github.event.inputs.tf-log-level || 'info' }}
 
@@ -44,7 +38,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: ${{ env.NEBARI_GH_BRANCH }}
           fetch-depth: 0
 
       - name: Set up Python


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://nebari.dev/community
-->

## Reference Issues or PRs
Closes #2836 

<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create a link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

## What does this implement/fix?

_Put a `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds a feature)
- [ ] Breaking change (fix or feature that would cause existing features not to work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Other (please describe):

## Testing

- [ ] Did you test the pull request locally?
- [ ] Did you add new tests?

## How to test this PR?
You won't be able to see the branch input textbox gone from the GitHub Actions UI until we merge the PR to main. However, you can compare this approach to our [local upgrade tests](https://github.com/nebari-dev/nebari/blob/855aa14ecc32625a98ec01b017acfc8a4af3c017/.github/workflows/test_local_upgrade.yaml), which don't specify the branch as an input and can still be run from an arbitrary branch:

<img width="1426" alt="image" src="https://github.com/user-attachments/assets/f5ba1f48-0c50-4e82-8805-17207fb210cc">


<!--
If relevant, please outline the steps required to test your contribution
and the expected outcomes from the proposed changes. Providing clear
testing instructions will help reviewers evaluate your contribution.
-->

## Any other comments?

<!--
Please be aware that we are a loose team of volunteers, so patience is necessary;
assistance handling other issues is very welcome.
We value all user contributions. If we are slow to review, either the pull request needs some benchmarking, tinkering,
convincing, etc., or the reviewers are likely busy. In either case,
we ask for your understanding during the
review process.
Thanks for contributing to Nebari 🙏🏼!
-->
