### PR TITLE
allow passing X.XX or X.XX.XX as k8s versions

### DIFF
--- a/src/_nebari/provider/cloud/google_cloud.py
+++ b/src/_nebari/provider/cloud/google_cloud.py
@@ -64,6 +64,16 @@ def kubernetes_versions(region: str) -> List[str]:
     return filter_by_highest_supported_k8s_version(supported_kubernetes_versions)
 
 
+def get_patch_version(full_version: str) -> str:
+    return full_version.split("-")[0]
+
+
+def get_minor_version(full_version: str) -> str:
+    patch_version = get_patch_version(full_version)
+    parts = patch_version.split(".")
+    return f"{parts[0]}.{parts[1]}"
+
+
 def cluster_exists(cluster_name: str, region: str) -> bool:
     """Check if a GKE cluster exists."""
     credentials, project_id = load_credentials()

--- a/src/_nebari/provider/cloud/google_cloud.py
+++ b/src/_nebari/provider/cloud/google_cloud.py
@@ -57,7 +57,7 @@ def kubernetes_versions(region: str) -> List[str]:
     credentials, project_id = load_credentials()
     client = container_v1.ClusterManagerClient(credentials=credentials)
     response = client.get_server_config(
-        name=f"projects/{project_id}/locations/{region}"
+        name=f"projects/{project_id}/locations/{region}", timeout=300
     )
     supported_kubernetes_versions = response.valid_master_versions
 

--- a/src/_nebari/stages/infrastructure/__init__.py
+++ b/src/_nebari/stages/infrastructure/__init__.py
@@ -8,7 +8,7 @@ import sys
 import tempfile
 from typing import Annotated, Any, Dict, List, Literal, Optional, Tuple, Type, Union
 
-from pydantic import Field, field_validator, model_validator
+from pydantic import ConfigDict, Field, field_validator, model_validator
 
 from _nebari import constants
 from _nebari.provider import terraform
@@ -359,6 +359,7 @@ DEFAULT_GCP_NODE_GROUPS = {
 
 
 class GoogleCloudPlatformProvider(schema.Base):
+    model_config = ConfigDict(coerce_numbers_to_str=True)
     region: str
     project: str
     kubernetes_version: str
@@ -373,6 +374,12 @@ class GoogleCloudPlatformProvider(schema.Base):
     master_authorized_networks_config: Optional[Union[GCPCIDRBlock, None]] = None
     private_cluster_config: Optional[Union[GCPPrivateClusterConfig, None]] = None
 
+    @field_validator("kubernetes_version", mode="before")
+    @classmethod
+    def transform_version_to_str(cls, value) -> str:
+        """Transforms the version to a string if it is not already."""
+        return str(value)
+
     @model_validator(mode="before")
     @classmethod
     def _check_input(cls, data: Any) -> Any:
@@ -383,8 +390,10 @@ class GoogleCloudPlatformProvider(schema.Base):
             )
 
         available_kubernetes_versions = google_cloud.kubernetes_versions(data["region"])
-        print(available_kubernetes_versions)
-        if data["kubernetes_version"] not in available_kubernetes_versions:
+        if not any(
+            v.startswith(str(data["kubernetes_version"]))
+            for v in available_kubernetes_versions
+        ):
             raise ValueError(
                 f"\nInvalid `kubernetes-version` provided: {data['kubernetes_version']}.\nPlease select from one of the following supported Kubernetes versions: {available_kubernetes_versions} or omit flag to use latest Kubernetes version available."
             )

--- a/src/_nebari/stages/infrastructure/__init__.py
+++ b/src/_nebari/stages/infrastructure/__init__.py
@@ -359,6 +359,8 @@ DEFAULT_GCP_NODE_GROUPS = {
 
 
 class GoogleCloudPlatformProvider(schema.Base):
+    # If you pass a major and minor version without a patch version
+    # yaml will pass it as a float, so we need to coerce it to a string
     model_config = ConfigDict(coerce_numbers_to_str=True)
     region: str
     project: str

--- a/src/_nebari/subcommands/init.py
+++ b/src/_nebari/subcommands/init.py
@@ -409,13 +409,15 @@ def check_cloud_provider_kubernetes_version(
         versions = google_cloud.kubernetes_versions(region)
 
         if not kubernetes_version or kubernetes_version == LATEST:
-            kubernetes_version = get_latest_kubernetes_version(versions)
+            kubernetes_version = google_cloud.get_patch_version(
+                get_latest_kubernetes_version(versions)
+            )
             rich.print(
                 DEFAULT_KUBERNETES_VERSION_MSG.format(
                     kubernetes_version=kubernetes_version
                 )
             )
-        if kubernetes_version not in versions:
+        if not any(v.startswith(kubernetes_version) for v in versions):
             raise ValueError(
                 f"Invalid Kubernetes version `{kubernetes_version}`. Please refer to the GCP docs for a list of valid versions: {versions}"
             )


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://nebari.dev/community
-->

## Reference Issues or PRs
Fixes #2822 
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create a link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

## What does this implement/fix?
Allows specifiying either major and minor versions, major minor and patch versions, or full versions of kubernetes for gcp. Also changes guided init so that if no version is specified, the latest patch version is used.

_Put a `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds a feature)
- [ ] Breaking change (fix or feature that would cause existing features not to work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Other (please describe):

## Testing

- [X] Did you test the pull request locally?
- [ ] Did you add new tests?

## How to test this PR?

<!--
If relevant, please outline the steps required to test your contribution
and the expected outcomes from the proposed changes. Providing clear
testing instructions will help reviewers evaluate your contribution.
-->
1. Run either `nebari init --guided-init` and don't specify a kubernetes version or `nebari init gcp -p your_project_name -d your_domain_name.org` 
2.  To validate, you can deploy to GCP or locally using `1.X`, `1.X.X`, and `1.X.X-gke.x`
2. Use 

## Any other comments?

<!--
Please be aware that we are a loose team of volunteers, so patience is necessary;
assistance handling other issues is very welcome.
We value all user contributions. If we are slow to review, either the pull request needs some benchmarking, tinkering,
convincing, etc., or the reviewers are likely busy. In either case,
we ask for your understanding during the
review process.
Thanks for contributing to Nebari 🙏🏼!
-->
