### PR TITLE
Disable AWS `launch_template` from nebari-config schema

### DIFF
--- a/src/_nebari/stages/infrastructure/__init__.py
+++ b/src/_nebari/stages/infrastructure/__init__.py
@@ -8,7 +8,7 @@ import sys
 import tempfile
 from typing import Annotated, Any, Dict, List, Literal, Optional, Tuple, Type, Union
 
-from pydantic import ConfigDict, Field, PrivateAttr, field_validator, model_validator
+from pydantic import ConfigDict, Field, field_validator, model_validator
 
 from _nebari import constants
 from _nebari.provider import terraform

--- a/src/_nebari/stages/infrastructure/__init__.py
+++ b/src/_nebari/stages/infrastructure/__init__.py
@@ -136,7 +136,7 @@ class AWSAmiTypes(str, enum.Enum):
 
 class AWSNodeLaunchTemplate(schema.Base):
     pre_bootstrap_command: Optional[str] = None
-    _ami_id: Optional[str] = PrivateAttr(default=None)
+    ami_id: Optional[str] = None
 
 
 class AWSNodeGroupInputVars(schema.Base):
@@ -152,10 +152,23 @@ class AWSNodeGroupInputVars(schema.Base):
     launch_template: Optional[AWSNodeLaunchTemplate] = None
 
 
-def construct_aws_ami_type(gpu_enabled: bool, launch_template: AWSNodeLaunchTemplate):
-    """Construct the AWS AMI type based on the provided parameters."""
+def construct_aws_ami_type(
+    gpu_enabled: bool, launch_template: AWSNodeLaunchTemplate
+) -> str:
+    """
+    This function selects the Amazon Machine Image (AMI) type for AWS nodes by evaluating
+    the provided parameters. The selection logic prioritizes the launch template over the
+    GPU flag.
 
-    if launch_template and launch_template._ami_id:
+    Returns the AMI type (str) determined by the following rules:
+        - Returns "CUSTOM" if a `launch_template` is provided and it includes a valid `ami_id`.
+        - Returns "AL2_x86_64_GPU" if `gpu_enabled` is True and no valid
+          `launch_template` is provided (None).
+        - Returns "AL2_x86_64" as the default AMI type if `gpu_enabled` is False and no
+          valid `launch_template` is provided (None).
+    """
+
+    if launch_template and getattr(launch_template, "ami_id", None):
         return "CUSTOM"
 
     if gpu_enabled:
@@ -480,7 +493,8 @@ class AWSNodeGroup(schema.Base):
     gpu: bool = False
     single_subnet: bool = False
     permissions_boundary: Optional[str] = None
-    launch_template: Optional[AWSNodeLaunchTemplate] = None
+    # Disabled as part of 2024.11.1 until #2832 is resolved
+    # launch_template: Optional[AWSNodeLaunchTemplate] = None
 
 
 DEFAULT_AWS_NODE_GROUPS = {
@@ -899,10 +913,10 @@ class KubernetesInfrastructureStage(NebariTerraformStage):
                         max_size=node_group.max_nodes,
                         single_subnet=node_group.single_subnet,
                         permissions_boundary=node_group.permissions_boundary,
-                        launch_template=node_group.launch_template,
+                        launch_template=None,
                         ami_type=construct_aws_ami_type(
                             gpu_enabled=node_group.gpu,
-                            launch_template=node_group.launch_template,
+                            launch_template=None,
                         ),
                     )
                     for name, node_group in self.config.amazon_web_services.node_groups.items()

--- a/src/_nebari/stages/infrastructure/__init__.py
+++ b/src/_nebari/stages/infrastructure/__init__.py
@@ -496,6 +496,14 @@ class AWSNodeGroup(schema.Base):
     # Disabled as part of 2024.11.1 until #2832 is resolved
     # launch_template: Optional[AWSNodeLaunchTemplate] = None
 
+    @model_validator(mode="before")
+    def check_launch_template(cls, values):
+        if "launch_template" in values:
+            raise ValueError(
+                "The 'launch_template' field is currently unavailable and has been removed from the configuration schema.\nPlease omit this field until it is reintroduced in a future update.",
+            )
+        return values
+
 
 DEFAULT_AWS_NODE_GROUPS = {
     "general": AWSNodeGroup(instance="m5.2xlarge", min_nodes=1, max_nodes=1),


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://nebari.dev/community
-->

## Reference Issues or PRs

<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create a link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

## What does this implement/fix?

This PR disables the user-facing object from the nebari-config schema while still keeping the logic introduced initially in #2621. 

### Motivation

The #2842 attempted to disable the `ami_id` setting from the `launch_template` configuration under the node groups. However, this change caused Terraform deployment issues because the aws node_group relied on the `ami_id` attribute internaly, leading to a failed Nebari deployments when it was removed in the linked PR.

Additionally, we've encountered recent internal connection issues with the nodes using just the `pre_bootstrap_command.` These issues indicated that the current configuration for `launch_template` is not functioning correctly.

It also includes:
- a custom error message in the schema validator for letting users know this is a temporary removal;
- A better docstring to the auxiliary `construct_aws_ami_type` function since the choice for the CUSTOM instance type depends on the presence of both `launch_template` and `ami_id`.

_Put a `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds a feature)
- [ ] Breaking change (fix or feature that would cause existing features not to work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Other (please describe):

## Testing

- [ ] Did you test the pull request locally?
- [ ] Did you add new tests?

## How to test this PR?

- init an aws config file
- (optional) run a deployment;
- Include a new node group with the `launch_template` field. This would simulate a scenario where the user has such a config already (for example):
```yaml
      launch_template:
        # Replace with your custom AMI ID
        ami_id: ami-0abcdef1234567890
        # Command to run before the node joins the cluster
        pre_bootstrap_command: |
          #!/bin/bash
          # This script is executed before the node is bootstrapped
          # You can use this script to install additional packages or configure the node
          # For example, to install the `htop` package, you can run:
          # sudo apt-get update
          # sudo apt-get install -y htop"
```
Though, just adding `launch_template` will trigger the error.
- run `nebari render` or `nebari validate` to trigger the load of the schemas. This should lead you to a ValueError

<!--
If relevant, please outline the steps required to test your contribution
and the expected outcomes from the proposed changes. Providing clear
testing instructions will help reviewers evaluate your contribution.
-->

## Any other comments?

<!--
Please be aware that we are a loose team of volunteers, so patience is necessary;
assistance handling other issues is very welcome.
We value all user contributions. If we are slow to review, either the pull request needs some benchmarking, tinkering,
convincing, etc., or the reviewers are likely busy. In either case,
we ask for your understanding during the
review process.
Thanks for contributing to Nebari 🙏🏼!
-->
