### PR TITLE
Update conda-store-ui tests for updated page verbage

### DIFF
--- a/tests/common/handlers.py
+++ b/tests/common/handlers.py
@@ -298,7 +298,9 @@ class CondaStore(JupyterLab):
 
     def _open_new_environment_tab(self):
         self.page.get_by_label("Create a new environment in").click()
-        expect(self.page.get_by_text("Create Environment")).to_be_visible()
+        expect(
+            self.page.get_by_role("button", name="Create", exact=True)
+        ).to_be_visible()
 
     def _assert_user_namespace(self):
         expect(


### PR DESCRIPTION
This PR fixes the broken conda-store ui tests which look for the `Create Environment` button. This button was renamed in https://github.com/conda-incubator/conda-store-ui/pull/389 to just `Create`.

This test might have started breaking after updating conda-store from 2024.3.1 to 2024.11.1.

## What does this implement/fix?

_Put a `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds a feature)
- [ ] Breaking change (fix or feature that would cause existing features not to work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Other (please describe):

## Testing

- [ ] Did you test the pull request locally?
- [ ] Did you add new tests?


