### PR TITLE
ignore trivy finding for public egress

### DIFF
--- a/src/_nebari/stages/infrastructure/template/aws/modules/network/main.tf
+++ b/src/_nebari/stages/infrastructure/template/aws/modules/network/main.tf
@@ -62,6 +62,7 @@ resource "aws_security_group" "main" {
     cidr_blocks = [var.vpc_cidr_block]
   }
 
+  #trivy:ignore:AVD-AWS-0104
   egress {
     description = "Allow all ports and protocols to exit the security group"
     from_port   = 0


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://nebari.dev/community
-->

## Reference Issues or PRs
closes #2882

<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create a link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

## What does this implement/fix?
This alert is because the security group has an egress rule that allows egress to `0.0.0.0/0`. Reference for the finding is at https://avd.aquasec.com/misconfig/aws/ec2/avd-aws-0104/

However, the nature of the type of work done in Nebari means that we need this rule, and since it is an egress rule we choose to accept this risk.

This PR causes trivy to ignore this finding for this resource. It is as narrowly scoped as possible so that if this rule finds other instances we can address them if needed.

_Put a `x` in the boxes that apply_

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds a feature)
- [ ] Breaking change (fix or feature that would cause existing features not to work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Other (please describe):

## Testing

- [ ] Did you test the pull request locally?
- [ ] Did you add new tests?

## How to test this PR?

<!--
If relevant, please outline the steps required to test your contribution
and the expected outcomes from the proposed changes. Providing clear
testing instructions will help reviewers evaluate your contribution.
-->
Merge and check the security table.
## Any other comments?

<!--
Please be aware that we are a loose team of volunteers, so patience is necessary;
assistance handling other issues is very welcome.
We value all user contributions. If we are slow to review, either the pull request needs some benchmarking, tinkering,
convincing, etc., or the reviewers are likely busy. In either case,
we ask for your understanding during the
review process.
Thanks for contributing to Nebari 🙏🏼!
-->
