### PR TITLE
[BUG] - Make sure to get envs when the number of envs is less than page limit

### DIFF
--- a/src/_nebari/stages/kubernetes_services/template/modules/kubernetes/services/jupyterhub/files/jupyterhub/02-spawner.py
+++ b/src/_nebari/stages/kubernetes_services/template/modules/kubernetes/services/jupyterhub/files/jupyterhub/02-spawner.py
@@ -73,19 +73,16 @@ def get_conda_store_environments(user_info: dict):
     # will contain all the environment info returned from the api
     env_data = []
 
-    # If there are more records than the specified size limit, then
-    # will need to page through to get all the available envs
-    if total_records > page_size:
-        # generate a list of urls to hit to build the response
-        urls = generate_paged_urls(base_url, total_records, page_size)
+    # generate a list of urls to hit to build the response
+    urls = generate_paged_urls(base_url, total_records, page_size)
 
-        # get content from urls
-        for url in urls:
-            response = http.request(
-                "GET", url, headers={"Authorization": f"Bearer {token}"}
-            )
-            decoded_response = json.loads(response.data.decode("UTF-8"))
-            env_data += decoded_response.get("data", [])
+    # get content from urls
+    for url in urls:
+        response = http.request(
+            "GET", url, headers={"Authorization": f"Bearer {token}"}
+        )
+        decoded_response = json.loads(response.data.decode("UTF-8"))
+        env_data += decoded_response.get("data", [])
 
     # Filter and return conda environments for the user
     return [f"{env['namespace']['name']}-{env['name']}" for env in env_data]


### PR DESCRIPTION
## What does this implement/fix?
Previously, if the number of environments is less than the default pagination size, no environments are shown to the user when launching jhubb apps.

This change ensures that all conda environments are retrieved when the number of environments is less than the DEFAULT_PAGE_SIZE_LIMIT.

follow up to https://github.com/nebari-dev/nebari/pull/2910

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds a feature)
- [ ] Breaking change (fix or feature that would cause existing features not to work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Other (please describe):

## Testing

- [x] Did you test the pull request locally?
- [ ] Did you add new tests?

## How to test this PR?

0. To test this PR you must have
  a. an installation of Nebari with jhub apps enabled
  b. at least 100 conda-store environments (or decrease the size_limit var in the PR to a sufficiently small number, like 2)
1. Navigate to the nebari home screen
2. Click on the deploy app button
3. Click on the drop down to select the conda store environment for the app
4. Notice that all the environments are available


