### PR TITLE
Fix issue with namespaces permission scopes

### DIFF
--- a/tests/common/handlers.py
+++ b/tests/common/handlers.py
@@ -308,7 +308,10 @@ class CondaStore(JupyterLab):
         time.sleep(2)
 
     def _open_new_environment_tab(self):
-        self.page.get_by_label("Create a new environment in").click()
+        self.page.get_by_role(
+            "link",
+            name=f"Create a new environment in the {self.nav.username} namespace",
+        ).click()
         expect(
             self.page.get_by_role("button", name="Create", exact=True)
         ).to_be_visible()

--- a/tests/tests_e2e/playwright/test_playwright.py
+++ b/tests/tests_e2e/playwright/test_playwright.py
@@ -89,6 +89,6 @@ def test_conda_store_ui(navigator, namespaces):
     namespaces.append(navigator.username)
     namespaces.sort()
 
-    assert shown_namespaces == namespaces
+    assert set(shown_namespaces).intersection(namespaces) == set(namespaces)
     # Clean up
     conda_store.reset_workspace()


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://nebari.dev/community
-->

## Reference Issues or PRs

<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create a link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

## What does this implement/fix?

I found a minor issue with the current conda-store UI check in the playwright tests; if the user has admin access over more than its namespace, the current locator (HTML ARIA tagging) returns multiple "create envs" buttons, which breaks the rest of the current logic.:
```shell
playwright._impl._errors.Error: Locator.click: Error: strict mode violation: get_by_label("Create a new environment in") resolved to 3 elements:
    1) <a tabindex="0" aria-disabled="false" href="/testuser/new-environment" aria-label="Create a new environment in the testuser namespace" class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary  css-3b4swr">…</a> aka get_by_role("link", name="Create a new environment in the testuser namespace")
    2) <a tabindex="0" aria-disabled="false" href="/custom1/new-environment" aria-label="Create a new environment in the custom1 namespace" class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary  css-3b4swr">…</a> aka get_by_role("link", name="Create a new environment in the custom1 namespace")
    3) <a tabindex="0" aria-disabled="false" href="/custom2/new-environment" aria-label="Create a new environment in the custom2 namespace" class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary  css-3b4swr">…</a> aka get_by_role("link", name="Create a new environment in the custom2 namespace")

Call log:
  - waiting for get_by_label("Create a new environment in")
```

This PR filters out to only the user namespace while also loosening the assertion with the expected default namespace against the cluster's current namespaces (if the user has more groups than the default, this returns an error in the assert right now):

```shell
AssertionError: assert ['analyst', 'custom1', 'custom2', 'developer', 'global', 'nebari-git', 'testuser', 'users'] == ['analyst', 'developer', 'global', 'nebari-git', 'testuser', 'users']
  
  At index 1 diff: 'custom1' != 'developer'
  Left contains 2 more items, first extra item: 'testuser'
  
  Full diff:
    [
        'analyst',
  +     'custom1',
  +     'custom2',
        'developer',
        'global',
        'nebari-git',
        'testuser',
        'users',
    ]
```


_Put a `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds a feature)
- [ ] Breaking change (fix or feature that would cause existing features not to work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Other (please describe):

## Testing

- [x] Did you test the pull request locally?
- [ ] Did you add new tests?

## How to test this PR?

- Deploy nebari locally and create at least one custom namespace besides the default ones, then create a new environment there;
- Run the playwright test:
  -  follow the readme instruction inside `/tests/.../playwright/README` for setup (`make setup` is your friend),  
  - run `pytest  test_playwright.py::test_conda_store_ui --numprocesses auto -vvv --slowmo 300`
<!--
If relevant, please outline the steps required to test your contribution
and the expected outcomes from the proposed changes. Providing clear
testing instructions will help reviewers evaluate your contribution.
-->

## Any other comments?

<!--
Please be aware that we are a loose team of volunteers, so patience is necessary;
assistance handling other issues is very welcome.
We value all user contributions. If we are slow to review, either the pull request needs some benchmarking, tinkering,
convincing, etc., or the reviewers are likely busy. In either case,
we ask for your understanding during the
review process.
Thanks for contributing to Nebari 🙏🏼!
-->
