### PR TITLE
Upgrade cirun AMI to ubuntu 24.04

### DIFF
--- a/.cirun.yml
+++ b/.cirun.yml
@@ -6,8 +6,8 @@ runners:
     cloud: aws
     # Instance Type has 8 vcpu, 32 GiB memory, Up to 5 Gbps Network Performance
     instance_type: t3a.2xlarge
-    # Custom AMI with docker/cypress/hub pre-installed
-    machine_image: ami-0a388df278199ff52
+    # Custom Ubuntu 24.04 AMI with docker/hub pre-installed
+    machine_image: ami-017ef4c53aac82e41
     # Region: Oregon
     region: us-west-2
     # Use Spot Instances for cost savings

--- a/.cirun.yml
+++ b/.cirun.yml
@@ -7,7 +7,7 @@ runners:
     # Instance Type has 8 vcpu, 32 GiB memory, Up to 5 Gbps Network Performance
     instance_type: t3a.2xlarge
     # Custom Ubuntu 24.04 AMI with docker/hub pre-installed
-    machine_image: ami-017ef4c53aac82e41
+    machine_image: ami-01b494943951b97c7
     # Region: Oregon
     region: us-west-2
     # Use Spot Instances for cost savings


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://nebari.dev/community
-->

## Reference Issues or PRs

It's been a long overdue, we have been using ubuntu 20 as of today, which causes warnings like these:

<img width="1158" alt="Screenshot 2025-02-11 at 11 07 27 pm" src="https://github.com/user-attachments/assets/34e8161d-6800-44f3-98b9-395889b4c096" />

Also our playwright installation is missing dependencies: https://github.com/nebari-dev/nebari/actions/runs/13273857606/job/37059318705#step:7:537

<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create a link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

## What does this implement/fix?

_Put a `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds a feature)
- [ ] Breaking change (fix or feature that would cause existing features not to work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [x] Build related changes
- [ ] Other (please describe):

## Testing

- [ ] Did you test the pull request locally?
- [ ] Did you add new tests?

## How to test this PR?

<!--
If relevant, please outline the steps required to test your contribution
and the expected outcomes from the proposed changes. Providing clear
testing instructions will help reviewers evaluate your contribution.
-->

## Any other comments?

<!--
Please be aware that we are a loose team of volunteers, so patience is necessary;
assistance handling other issues is very welcome.
We value all user contributions. If we are slow to review, either the pull request needs some benchmarking, tinkering,
convincing, etc., or the reviewers are likely busy. In either case,
we ask for your understanding during the
review process.
Thanks for contributing to Nebari 🙏🏼!
-->
