### PR TITLE
allow eks_public_access_cidrs to be optionally set in nebari-config.yaml

### DIFF
--- a/src/_nebari/stages/infrastructure/__init__.py
+++ b/src/_nebari/stages/infrastructure/__init__.py
@@ -318,8 +318,7 @@ class GoogleCloudPlatformProvider(schema.Base):
         available_regions = google_cloud.regions()
         if data["region"] not in available_regions:
             raise ValueError(
-                f"Google Cloud region={
-                    data['region']} is not one of {available_regions}"
+                f"Google Cloud region={data['region']} is not one of {available_regions}"
             )
 
         available_kubernetes_versions = google_cloud.kubernetes_versions(data["region"])
@@ -342,7 +341,7 @@ class GoogleCloudPlatformProvider(schema.Base):
                 )
                 if instance not in available_instances:
                     raise ValueError(
-                        f"Google Cloud Platform instance { instance} not one of available instance types={available_instances}"
+                        f"Google Cloud Platform instance {instance} not one of available instance types={available_instances}"
                     )
 
         return data
@@ -392,7 +391,7 @@ class AzureProvider(schema.Base):
             value = available_kubernetes_versions[-1]
         elif value not in available_kubernetes_versions:
             raise ValueError(
-                f"\nInvalid `kubernetes-version` provided: {value}.\nPlease select from one of the following supported Kubernetes versions: { available_kubernetes_versions} or omit flag to use latest Kubernetes version available."
+                f"\nInvalid `kubernetes-version` provided: {value}.\nPlease select from one of the following supported Kubernetes versions: {available_kubernetes_versions} or omit flag to use latest Kubernetes version available."
             )
         return value
 
@@ -404,7 +403,7 @@ class AzureProvider(schema.Base):
         length = len(value) + len(AZURE_NODE_RESOURCE_GROUP_SUFFIX)
         if length < 1 or length > 90:
             raise ValueError(
-                f"Azure Resource Group name must be between 1 and 90 characters long, when combined with the suffix `{ AZURE_NODE_RESOURCE_GROUP_SUFFIX}`."
+                f"Azure Resource Group name must be between 1 and 90 characters long, when combined with the suffix `{AZURE_NODE_RESOURCE_GROUP_SUFFIX}`."
             )
         if not re.match(r"^[\w\-\.\(\)]+$", value):
             raise ValueError(
@@ -476,7 +475,7 @@ class AmazonWebServicesProvider(schema.Base):
         available_regions = amazon_web_services.regions(data["region"])
         if data["region"] not in available_regions:
             raise ValueError(
-                f"Amazon Web Services region={ data['region']} is not one of {available_regions}"
+                f"Amazon Web Services region={data['region']} is not one of {available_regions}"
             )
 
         # check if kubernetes version is valid
@@ -489,7 +488,7 @@ class AmazonWebServicesProvider(schema.Base):
             data["kubernetes_version"] = available_kubernetes_versions[-1]
         elif data["kubernetes_version"] not in available_kubernetes_versions:
             raise ValueError(
-                f"\nInvalid `kubernetes-version` provided: {data['kubernetes_version']}.\nPlease select from one of the following supported Kubernetes versions: { available_kubernetes_versions} or omit flag to use latest Kubernetes version available."
+                f"\nInvalid `kubernetes-version` provided: {data['kubernetes_version']}.\nPlease select from one of the following supported Kubernetes versions: {available_kubernetes_versions} or omit flag to use latest Kubernetes version available."
             )
 
         # check if availability zones are valid
@@ -500,7 +499,7 @@ class AmazonWebServicesProvider(schema.Base):
             for zone in data["availability_zones"]:
                 if zone not in available_zones:
                     raise ValueError(
-                        f"Amazon Web Services availability zone={ zone} is not one of {available_zones}"
+                        f"Amazon Web Services availability zone={zone} is not one of {available_zones}"
                     )
 
         # check if instances are valid
@@ -514,7 +513,7 @@ class AmazonWebServicesProvider(schema.Base):
                 )
                 if instance not in available_instances:
                     raise ValueError(
-                        f"Amazon Web Services instance { node_group.instance} not one of available instance types={available_instances}"
+                        f"Amazon Web Services instance {node_group.instance} not one of available instance types={available_instances}"
                     )
 
         # check if kms key is valid
@@ -536,22 +535,22 @@ class AmazonWebServicesProvider(schema.Base):
             # Raise error if key is not a customer managed key
             if available_kms_keys[key_id].KeyManager != "CUSTOMER":
                 raise ValueError(
-                    f"Amazon Web Services KMS Key with ID { key_id} is not a customer managed key"
+                    f"Amazon Web Services KMS Key with ID {key_id} is not a customer managed key"
                 )
             # Symmetric KMS keys with Encrypt and decrypt key-usage have the SYMMETRIC_DEFAULT key-spec
             # EKS cluster encryption requires a Symmetric key that is set to encrypt and decrypt data
             if available_kms_keys[key_id].KeySpec != "SYMMETRIC_DEFAULT":
                 if available_kms_keys[key_id].KeyUsage == "GENERATE_VERIFY_MAC":
                     raise ValueError(
-                        f"Amazon Web Services KMS Key with ID { key_id} does not have KeyUsage set to 'Encrypt and decrypt' data"
+                        f"Amazon Web Services KMS Key with ID {key_id} does not have KeyUsage set to 'Encrypt and decrypt' data"
                     )
                 elif available_kms_keys[key_id].KeyUsage != "ENCRYPT_DECRYPT":
                     raise ValueError(
-                        f"Amazon Web Services KMS Key with ID { key_id} is not of type Symmetric, and KeyUsage not set to 'Encrypt and decrypt' data"
+                        f"Amazon Web Services KMS Key with ID {key_id} is not of type Symmetric, and KeyUsage not set to 'Encrypt and decrypt' data"
                     )
                 else:
                     raise ValueError(
-                        f"Amazon Web Services KMS Key with ID { key_id} is not of type Symmetric"
+                        f"Amazon Web Services KMS Key with ID {key_id} is not of type Symmetric"
                     )
 
         return data
@@ -636,7 +635,7 @@ class InputSchema(schema.Base):
             extra_provider_config = set_providers - {expected_provider_config}
             if extra_provider_config:
                 warnings.warn(
-                    f"Provider is set to {getattr(provider, 'value', provider)},  but configuration defined for other providers: { extra_provider_config}"
+                    f"Provider is set to {getattr(provider, 'value', provider)},  but configuration defined for other providers: {extra_provider_config}"
                 )
 
         else:
@@ -889,17 +888,17 @@ class KubernetesInfrastructureStage(NebariTerraformStage):
             result = api_instance.list_namespace()
         except ApiException:
             print(
-                f"ERROR: After stage={ self.name} unable to connect to kubernetes cluster"
+                f"ERROR: After stage={self.name} unable to connect to kubernetes cluster"
             )
             sys.exit(1)
 
         if len(result.items) < 1:
             print(
-                f"ERROR: After stage={ self.name} no nodes provisioned within kubernetes cluster"
+                f"ERROR: After stage={self.name} no nodes provisioned within kubernetes cluster"
             )
             sys.exit(1)
 
-        print(f"After stage={ self.name} kubernetes cluster successfully provisioned")
+        print(f"After stage={self.name} kubernetes cluster successfully provisioned")
 
     def set_outputs(
         self, stage_outputs: Dict[str, Dict[str, Any]], outputs: Dict[str, Any]

--- a/src/_nebari/stages/infrastructure/__init__.py
+++ b/src/_nebari/stages/infrastructure/__init__.py
@@ -318,8 +318,7 @@ class GoogleCloudPlatformProvider(schema.Base):
         available_regions = google_cloud.regions()
         if data["region"] not in available_regions:
             raise ValueError(
-                f"Google Cloud region={
-                    data['region']} is not one of {available_regions}"
+                f"Google Cloud region={data['region']} is not one of {available_regions}"
             )
 
         available_kubernetes_versions = google_cloud.kubernetes_versions(data["region"])
@@ -916,7 +915,7 @@ class KubernetesInfrastructureStage(NebariTerraformStage):
 
         print(
             f"After stage={
-              self.name} kubernetes cluster successfully provisioned"
+                self.name} kubernetes cluster successfully provisioned"
         )
 
     def set_outputs(

--- a/src/_nebari/stages/infrastructure/__init__.py
+++ b/src/_nebari/stages/infrastructure/__init__.py
@@ -318,7 +318,8 @@ class GoogleCloudPlatformProvider(schema.Base):
         available_regions = google_cloud.regions()
         if data["region"] not in available_regions:
             raise ValueError(
-                f"Google Cloud region={data['region']} is not one of {available_regions}"
+                f"Google Cloud region={
+                    data['region']} is not one of {available_regions}"
             )
 
         available_kubernetes_versions = google_cloud.kubernetes_versions(data["region"])
@@ -327,9 +328,8 @@ class GoogleCloudPlatformProvider(schema.Base):
             for v in available_kubernetes_versions
         ):
             raise ValueError(
-                f"\nInvalid `kubernetes-version` provided: {data['kubernetes_version']}.\nPlease select from one of the following supported Kubernetes versions: {
-                    available_kubernetes_versions} or omit flag to use latest Kubernetes version available."
-            )
+                f"\nInvalid `kubernetes-version` provided: {data['kubernetes_version']}.\nPlease select from one of the following supported Kubernetes versions: {available_kubernetes_versions} or omit flag to use latest Kubernetes version available."
+            )  # noqa
 
         # check if instances are valid
         available_instances = google_cloud.instances(data["region"])
@@ -342,8 +342,7 @@ class GoogleCloudPlatformProvider(schema.Base):
                 )
                 if instance not in available_instances:
                     raise ValueError(
-                        f"Google Cloud Platform instance {
-                            instance} not one of available instance types={available_instances}"
+                        f"Google Cloud Platform instance { instance} not one of available instance types={available_instances}"
                     )
 
         return data
@@ -393,8 +392,7 @@ class AzureProvider(schema.Base):
             value = available_kubernetes_versions[-1]
         elif value not in available_kubernetes_versions:
             raise ValueError(
-                f"\nInvalid `kubernetes-version` provided: {value}.\nPlease select from one of the following supported Kubernetes versions: {
-                    available_kubernetes_versions} or omit flag to use latest Kubernetes version available."
+                f"\nInvalid `kubernetes-version` provided: {value}.\nPlease select from one of the following supported Kubernetes versions: { available_kubernetes_versions} or omit flag to use latest Kubernetes version available."
             )
         return value
 
@@ -406,8 +404,7 @@ class AzureProvider(schema.Base):
         length = len(value) + len(AZURE_NODE_RESOURCE_GROUP_SUFFIX)
         if length < 1 or length > 90:
             raise ValueError(
-                f"Azure Resource Group name must be between 1 and 90 characters long, when combined with the suffix `{
-                    AZURE_NODE_RESOURCE_GROUP_SUFFIX}`."
+                f"Azure Resource Group name must be between 1 and 90 characters long, when combined with the suffix `{ AZURE_NODE_RESOURCE_GROUP_SUFFIX}`."
             )
         if not re.match(r"^[\w\-\.\(\)]+$", value):
             raise ValueError(
@@ -479,8 +476,7 @@ class AmazonWebServicesProvider(schema.Base):
         available_regions = amazon_web_services.regions(data["region"])
         if data["region"] not in available_regions:
             raise ValueError(
-                f"Amazon Web Services region={
-                    data['region']} is not one of {available_regions}"
+                f"Amazon Web Services region={ data['region']} is not one of {available_regions}"
             )
 
         # check if kubernetes version is valid
@@ -493,8 +489,7 @@ class AmazonWebServicesProvider(schema.Base):
             data["kubernetes_version"] = available_kubernetes_versions[-1]
         elif data["kubernetes_version"] not in available_kubernetes_versions:
             raise ValueError(
-                f"\nInvalid `kubernetes-version` provided: {data['kubernetes_version']}.\nPlease select from one of the following supported Kubernetes versions: {
-                    available_kubernetes_versions} or omit flag to use latest Kubernetes version available."
+                f"\nInvalid `kubernetes-version` provided: {data['kubernetes_version']}.\nPlease select from one of the following supported Kubernetes versions: { available_kubernetes_versions} or omit flag to use latest Kubernetes version available."
             )
 
         # check if availability zones are valid
@@ -505,8 +500,7 @@ class AmazonWebServicesProvider(schema.Base):
             for zone in data["availability_zones"]:
                 if zone not in available_zones:
                     raise ValueError(
-                        f"Amazon Web Services availability zone={
-                            zone} is not one of {available_zones}"
+                        f"Amazon Web Services availability zone={ zone} is not one of {available_zones}"
                     )
 
         # check if instances are valid
@@ -520,8 +514,7 @@ class AmazonWebServicesProvider(schema.Base):
                 )
                 if instance not in available_instances:
                     raise ValueError(
-                        f"Amazon Web Services instance {
-                            node_group.instance} not one of available instance types={available_instances}"
+                        f"Amazon Web Services instance { node_group.instance} not one of available instance types={available_instances}"
                     )
 
         # check if kms key is valid
@@ -543,26 +536,22 @@ class AmazonWebServicesProvider(schema.Base):
             # Raise error if key is not a customer managed key
             if available_kms_keys[key_id].KeyManager != "CUSTOMER":
                 raise ValueError(
-                    f"Amazon Web Services KMS Key with ID {
-                        key_id} is not a customer managed key"
+                    f"Amazon Web Services KMS Key with ID { key_id} is not a customer managed key"
                 )
             # Symmetric KMS keys with Encrypt and decrypt key-usage have the SYMMETRIC_DEFAULT key-spec
             # EKS cluster encryption requires a Symmetric key that is set to encrypt and decrypt data
             if available_kms_keys[key_id].KeySpec != "SYMMETRIC_DEFAULT":
                 if available_kms_keys[key_id].KeyUsage == "GENERATE_VERIFY_MAC":
                     raise ValueError(
-                        f"Amazon Web Services KMS Key with ID {
-                            key_id} does not have KeyUsage set to 'Encrypt and decrypt' data"
+                        f"Amazon Web Services KMS Key with ID { key_id} does not have KeyUsage set to 'Encrypt and decrypt' data"
                     )
                 elif available_kms_keys[key_id].KeyUsage != "ENCRYPT_DECRYPT":
                     raise ValueError(
-                        f"Amazon Web Services KMS Key with ID {
-                            key_id} is not of type Symmetric, and KeyUsage not set to 'Encrypt and decrypt' data"
+                        f"Amazon Web Services KMS Key with ID { key_id} is not of type Symmetric, and KeyUsage not set to 'Encrypt and decrypt' data"
                     )
                 else:
                     raise ValueError(
-                        f"Amazon Web Services KMS Key with ID {
-                            key_id} is not of type Symmetric"
+                        f"Amazon Web Services KMS Key with ID { key_id} is not of type Symmetric"
                     )
 
         return data
@@ -647,8 +636,7 @@ class InputSchema(schema.Base):
             extra_provider_config = set_providers - {expected_provider_config}
             if extra_provider_config:
                 warnings.warn(
-                    f"Provider is set to {getattr(provider, 'value', provider)},  but configuration defined for other providers: {
-                        extra_provider_config}"
+                    f"Provider is set to {getattr(provider, 'value', provider)},  but configuration defined for other providers: { extra_provider_config}"
                 )
 
         else:
@@ -901,22 +889,17 @@ class KubernetesInfrastructureStage(NebariTerraformStage):
             result = api_instance.list_namespace()
         except ApiException:
             print(
-                f"ERROR: After stage={
-                    self.name} unable to connect to kubernetes cluster"
+                f"ERROR: After stage={ self.name} unable to connect to kubernetes cluster"
             )
             sys.exit(1)
 
         if len(result.items) < 1:
             print(
-                f"ERROR: After stage={
-                    self.name} no nodes provisioned within kubernetes cluster"
+                f"ERROR: After stage={ self.name} no nodes provisioned within kubernetes cluster"
             )
             sys.exit(1)
 
-        print(
-            f"After stage={
-                self.name} kubernetes cluster successfully provisioned"
-        )
+        print(f"After stage={ self.name} kubernetes cluster successfully provisioned")
 
     def set_outputs(
         self, stage_outputs: Dict[str, Dict[str, Any]], outputs: Dict[str, Any]

--- a/src/_nebari/stages/infrastructure/__init__.py
+++ b/src/_nebari/stages/infrastructure/__init__.py
@@ -170,6 +170,7 @@ class AWSInputVars(schema.Base):
         Literal["private", "public", "public_and_private"]
     ] = "public"
     eks_kms_arn: Optional[str] = None
+    eks_public_access_cidrs: Optional[List[str]] = ["0.0.0.0/0"]
     node_groups: List[AWSNodeGroupInputVars]
     availability_zones: List[str]
     vpc_cidr_block: str
@@ -317,7 +318,8 @@ class GoogleCloudPlatformProvider(schema.Base):
         available_regions = google_cloud.regions()
         if data["region"] not in available_regions:
             raise ValueError(
-                f"Google Cloud region={data['region']} is not one of {available_regions}"
+                f"Google Cloud region={
+                    data['region']} is not one of {available_regions}"
             )
 
         available_kubernetes_versions = google_cloud.kubernetes_versions(data["region"])
@@ -326,7 +328,8 @@ class GoogleCloudPlatformProvider(schema.Base):
             for v in available_kubernetes_versions
         ):
             raise ValueError(
-                f"\nInvalid `kubernetes-version` provided: {data['kubernetes_version']}.\nPlease select from one of the following supported Kubernetes versions: {available_kubernetes_versions} or omit flag to use latest Kubernetes version available."
+                f"\nInvalid `kubernetes-version` provided: {data['kubernetes_version']}.\nPlease select from one of the following supported Kubernetes versions: {
+                    available_kubernetes_versions} or omit flag to use latest Kubernetes version available."
             )
 
         # check if instances are valid
@@ -340,7 +343,8 @@ class GoogleCloudPlatformProvider(schema.Base):
                 )
                 if instance not in available_instances:
                     raise ValueError(
-                        f"Google Cloud Platform instance {instance} not one of available instance types={available_instances}"
+                        f"Google Cloud Platform instance {
+                            instance} not one of available instance types={available_instances}"
                     )
 
         return data
@@ -390,7 +394,8 @@ class AzureProvider(schema.Base):
             value = available_kubernetes_versions[-1]
         elif value not in available_kubernetes_versions:
             raise ValueError(
-                f"\nInvalid `kubernetes-version` provided: {value}.\nPlease select from one of the following supported Kubernetes versions: {available_kubernetes_versions} or omit flag to use latest Kubernetes version available."
+                f"\nInvalid `kubernetes-version` provided: {value}.\nPlease select from one of the following supported Kubernetes versions: {
+                    available_kubernetes_versions} or omit flag to use latest Kubernetes version available."
             )
         return value
 
@@ -402,7 +407,8 @@ class AzureProvider(schema.Base):
         length = len(value) + len(AZURE_NODE_RESOURCE_GROUP_SUFFIX)
         if length < 1 or length > 90:
             raise ValueError(
-                f"Azure Resource Group name must be between 1 and 90 characters long, when combined with the suffix `{AZURE_NODE_RESOURCE_GROUP_SUFFIX}`."
+                f"Azure Resource Group name must be between 1 and 90 characters long, when combined with the suffix `{
+                    AZURE_NODE_RESOURCE_GROUP_SUFFIX}`."
             )
         if not re.match(r"^[\w\-\.\(\)]+$", value):
             raise ValueError(
@@ -457,6 +463,7 @@ class AmazonWebServicesProvider(schema.Base):
     eks_endpoint_access: Optional[
         Literal["private", "public", "public_and_private"]
     ] = "public"
+    eks_public_access_cidrs: Optional[List[str]] = ["0.0.0.0/0"]
     eks_kms_arn: Optional[str] = None
     existing_subnet_ids: Optional[List[str]] = None
     existing_security_group_id: Optional[str] = None
@@ -473,7 +480,8 @@ class AmazonWebServicesProvider(schema.Base):
         available_regions = amazon_web_services.regions(data["region"])
         if data["region"] not in available_regions:
             raise ValueError(
-                f"Amazon Web Services region={data['region']} is not one of {available_regions}"
+                f"Amazon Web Services region={
+                    data['region']} is not one of {available_regions}"
             )
 
         # check if kubernetes version is valid
@@ -486,7 +494,8 @@ class AmazonWebServicesProvider(schema.Base):
             data["kubernetes_version"] = available_kubernetes_versions[-1]
         elif data["kubernetes_version"] not in available_kubernetes_versions:
             raise ValueError(
-                f"\nInvalid `kubernetes-version` provided: {data['kubernetes_version']}.\nPlease select from one of the following supported Kubernetes versions: {available_kubernetes_versions} or omit flag to use latest Kubernetes version available."
+                f"\nInvalid `kubernetes-version` provided: {data['kubernetes_version']}.\nPlease select from one of the following supported Kubernetes versions: {
+                    available_kubernetes_versions} or omit flag to use latest Kubernetes version available."
             )
 
         # check if availability zones are valid
@@ -497,7 +506,8 @@ class AmazonWebServicesProvider(schema.Base):
             for zone in data["availability_zones"]:
                 if zone not in available_zones:
                     raise ValueError(
-                        f"Amazon Web Services availability zone={zone} is not one of {available_zones}"
+                        f"Amazon Web Services availability zone={
+                            zone} is not one of {available_zones}"
                     )
 
         # check if instances are valid
@@ -511,7 +521,8 @@ class AmazonWebServicesProvider(schema.Base):
                 )
                 if instance not in available_instances:
                     raise ValueError(
-                        f"Amazon Web Services instance {node_group.instance} not one of available instance types={available_instances}"
+                        f"Amazon Web Services instance {
+                            node_group.instance} not one of available instance types={available_instances}"
                     )
 
         # check if kms key is valid
@@ -526,28 +537,33 @@ class AmazonWebServicesProvider(schema.Base):
                 or available_kms_keys[key_id[0]].Arn != data["eks_kms_arn"]
             ):
                 raise ValueError(
-                    f"Amazon Web Services KMS Key with ARN {data['eks_kms_arn']} not one of available/enabled keys={[v.Arn for v in available_kms_keys.values() if v.KeyManager=='CUSTOMER' and v.KeySpec=='SYMMETRIC_DEFAULT']}"
+                    f"Amazon Web Services KMS Key with ARN {data['eks_kms_arn']} not one of available/enabled keys={
+                        [v.Arn for v in available_kms_keys.values() if v.KeyManager == 'CUSTOMER' and v.KeySpec == 'SYMMETRIC_DEFAULT']}"
                 )
             key_id = key_id[0]
             # Raise error if key is not a customer managed key
             if available_kms_keys[key_id].KeyManager != "CUSTOMER":
                 raise ValueError(
-                    f"Amazon Web Services KMS Key with ID {key_id} is not a customer managed key"
+                    f"Amazon Web Services KMS Key with ID {
+                        key_id} is not a customer managed key"
                 )
             # Symmetric KMS keys with Encrypt and decrypt key-usage have the SYMMETRIC_DEFAULT key-spec
             # EKS cluster encryption requires a Symmetric key that is set to encrypt and decrypt data
             if available_kms_keys[key_id].KeySpec != "SYMMETRIC_DEFAULT":
                 if available_kms_keys[key_id].KeyUsage == "GENERATE_VERIFY_MAC":
                     raise ValueError(
-                        f"Amazon Web Services KMS Key with ID {key_id} does not have KeyUsage set to 'Encrypt and decrypt' data"
+                        f"Amazon Web Services KMS Key with ID {
+                            key_id} does not have KeyUsage set to 'Encrypt and decrypt' data"
                     )
                 elif available_kms_keys[key_id].KeyUsage != "ENCRYPT_DECRYPT":
                     raise ValueError(
-                        f"Amazon Web Services KMS Key with ID {key_id} is not of type Symmetric, and KeyUsage not set to 'Encrypt and decrypt' data"
+                        f"Amazon Web Services KMS Key with ID {
+                            key_id} is not of type Symmetric, and KeyUsage not set to 'Encrypt and decrypt' data"
                     )
                 else:
                     raise ValueError(
-                        f"Amazon Web Services KMS Key with ID {key_id} is not of type Symmetric"
+                        f"Amazon Web Services KMS Key with ID {
+                            key_id} is not of type Symmetric"
                     )
 
         return data
@@ -632,7 +648,8 @@ class InputSchema(schema.Base):
             extra_provider_config = set_providers - {expected_provider_config}
             if extra_provider_config:
                 warnings.warn(
-                    f"Provider is set to {getattr(provider, 'value', provider)},  but configuration defined for other providers: {extra_provider_config}"
+                    f"Provider is set to {getattr(provider, 'value', provider)},  but configuration defined for other providers: {
+                        extra_provider_config}"
                 )
 
         else:
@@ -835,6 +852,7 @@ class KubernetesInfrastructureStage(NebariTerraformStage):
                 name=self.config.escaped_project_name,
                 environment=self.config.namespace,
                 eks_endpoint_access=self.config.amazon_web_services.eks_endpoint_access,
+                eks_public_access_cidrs=self.config.amazon_web_services.eks_public_access_cidrs,
                 eks_kms_arn=self.config.amazon_web_services.eks_kms_arn,
                 existing_subnet_ids=self.config.amazon_web_services.existing_subnet_ids,
                 existing_security_group_id=self.config.amazon_web_services.existing_security_group_id,
@@ -884,17 +902,22 @@ class KubernetesInfrastructureStage(NebariTerraformStage):
             result = api_instance.list_namespace()
         except ApiException:
             print(
-                f"ERROR: After stage={self.name} unable to connect to kubernetes cluster"
+                f"ERROR: After stage={
+                    self.name} unable to connect to kubernetes cluster"
             )
             sys.exit(1)
 
         if len(result.items) < 1:
             print(
-                f"ERROR: After stage={self.name} no nodes provisioned within kubernetes cluster"
+                f"ERROR: After stage={
+                    self.name} no nodes provisioned within kubernetes cluster"
             )
             sys.exit(1)
 
-        print(f"After stage={self.name} kubernetes cluster successfully provisioned")
+        print(
+            f"After stage={
+              self.name} kubernetes cluster successfully provisioned"
+        )
 
     def set_outputs(
         self, stage_outputs: Dict[str, Dict[str, Any]], outputs: Dict[str, Any]

--- a/src/_nebari/stages/infrastructure/__init__.py
+++ b/src/_nebari/stages/infrastructure/__init__.py
@@ -528,8 +528,7 @@ class AmazonWebServicesProvider(schema.Base):
                 or available_kms_keys[key_id[0]].Arn != data["eks_kms_arn"]
             ):
                 raise ValueError(
-                    f"Amazon Web Services KMS Key with ARN {data['eks_kms_arn']} not one of available/enabled keys={
-                        [v.Arn for v in available_kms_keys.values() if v.KeyManager == 'CUSTOMER' and v.KeySpec == 'SYMMETRIC_DEFAULT']}"
+                    f"Amazon Web Services KMS Key with ARN {data['eks_kms_arn']} not one of available/enabled keys={ [v.Arn for v in available_kms_keys.values() if v.KeyManager == 'CUSTOMER' and v.KeySpec == 'SYMMETRIC_DEFAULT']}"
                 )
             key_id = key_id[0]
             # Raise error if key is not a customer managed key

--- a/src/_nebari/stages/infrastructure/template/aws/modules/kubernetes/main.tf
+++ b/src/_nebari/stages/infrastructure/template/aws/modules/kubernetes/main.tf
@@ -8,10 +8,13 @@ resource "aws_eks_cluster" "main" {
   vpc_config {
     security_group_ids = var.cluster_security_groups
     subnet_ids         = var.cluster_subnets
+    # ignored because this is set through the eks_endpoint_access variable
     #trivy:ignore:AVD-AWS-0040
     endpoint_public_access  = var.endpoint_public_access
     endpoint_private_access = var.endpoint_private_access
-    public_access_cidrs     = var.public_access_cidrs
+    # ignored because this is set through the eks_public_access_cidrs variable
+    #trivy:ignore:AVD-AWS-0041
+    public_access_cidrs = var.public_access_cidrs
   }
 
   # Only set encryption_config if eks_kms_arn is not null


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://nebari.dev/community
-->

## Reference Issues or PRs
closes #2881 
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create a link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

## What does this implement/fix?
adds ability to specify `aws.eks_public_access_cidr` in your nebari-config.yaml


_Put a `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds a feature)
- [ ] Breaking change (fix or feature that would cause existing features not to work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Other (please describe):

## Testing

- [X] Did you test the pull request locally?
- [ ] Did you add new tests?

## How to test this PR?

Deploy to AWS

Go to the EKS console and under the `networking` tab, check that `Public access source allowlist` says `"0.0.0.0/0"`

add `eks_public_access_cidrs: ["{YOUR_PUBLIC_IP}/32"]` to your config under the AWS object

ex:
```
amazon_web_services:
  kubernetes_version: '1.31'
  region: us-east-2
  eks_public_access_cidrs: ["12.345.678.910/32"]
  node_groups:
    general:
      instance: m5.2xlarge
      min_nodes: 1
      max_nodes: 1
      gpu: false
      single_subnet: false
      permissions_boundary:
    user:
      instance: m5.xlarge
      min_nodes: 0
      max_nodes: 5
      gpu: false
      single_subnet: false
      permissions_boundary:
    worker:
      instance: m5.xlarge
      min_nodes: 0
      max_nodes: 5
      gpu: false
      single_subnet: false
      permissions_boundary:
```

Redeploy

Go to the EKS console and check that `Public access source allowlist` now reflects your configured range


<!--
If relevant, please outline the steps required to test your contribution
and the expected outcomes from the proposed changes. Providing clear
testing instructions will help reviewers evaluate your contribution.
-->

## Any other comments?
This is also feature parity for Azure and GCP
<!--
Please be aware that we are a loose team of volunteers, so patience is necessary;
assistance handling other issues is very welcome.
We value all user contributions. If we are slow to review, either the pull request needs some benchmarking, tinkering,
convincing, etc., or the reviewers are likely busy. In either case,
we ask for your understanding during the
review process.
Thanks for contributing to Nebari 🙏🏼!
-->
