### PR TITLE
fix ansi color reset bug

### DIFF
--- a/src/_nebari/utils.py
+++ b/src/_nebari/utils.py
@@ -64,6 +64,7 @@ def process_streams(
 
     outputs = {"stdout": [], "stderr": []}
     partial = {"stdout": b"", "stderr": b""}
+    reset_code = b"\x1b[0m"  # ANSI reset code
 
     try:
         while True:
@@ -109,6 +110,15 @@ def process_streams(
                             sys.stderr.flush()
                         else:
                             outputs["stderr"].append(line_w_newline)
+
+        # Add reset code when we're done processing output
+        if print_stdout:
+            sys.stdout.buffer.write(reset_code)
+            sys.stdout.flush()
+        if print_stderr:
+            sys.stderr.buffer.write(reset_code)
+            sys.stderr.flush()
+
     finally:
         sel.close()
         if process.stdout:


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://nebari.dev/community
-->

## Reference Issues or PRs
Deploy local.  This is what the logs look like at the end (see image).
![image](https://github.com/user-attachments/assets/9a19ca73-592b-4181-9cac-87bf23d746fd)

Notice the green ansi coloring continues after tofu logs are complete.  This PR sets the ansi reset code at the end of the log capture fixing the issue.

After this fix they look like
![image](https://github.com/user-attachments/assets/3556c226-b0ec-4a9e-ba9b-5fa5590e6214)



<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create a link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

## What does this implement/fix?

_Put a `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds a feature)
- [ ] Breaking change (fix or feature that would cause existing features not to work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Other (please describe):

## Testing

- [x] Did you test the pull request locally?
- [ ] Did you add new tests?

## How to test this PR?
Deploy locally, and see that the log coloring looks correct at the end of the deployment.

<!--
If relevant, please outline the steps required to test your contribution
and the expected outcomes from the proposed changes. Providing clear
testing instructions will help reviewers evaluate your contribution.
-->

## Any other comments?

<!--
Please be aware that we are a loose team of volunteers, so patience is necessary;
assistance handling other issues is very welcome.
We value all user contributions. If we are slow to review, either the pull request needs some benchmarking, tinkering,
convincing, etc., or the reviewers are likely busy. In either case,
we ask for your understanding during the
review process.
Thanks for contributing to Nebari 🙏🏼!
-->
