### PR TITLE
Moves nodes to private subnets. 

### DIFF
--- a/src/_nebari/stages/infrastructure/__init__.py
+++ b/src/_nebari/stages/infrastructure/__init__.py
@@ -168,7 +168,7 @@ class AWSInputVars(schema.Base):
     kubernetes_version: str
     eks_endpoint_access: Optional[
         Literal["private", "public", "public_and_private"]
-    ] = "public"
+    ] = "public_and_private"
     eks_kms_arn: Optional[str] = None
     eks_public_access_cidrs: Optional[List[str]] = ["0.0.0.0/0"]
     node_groups: List[AWSNodeGroupInputVars]
@@ -457,7 +457,7 @@ class AmazonWebServicesProvider(schema.Base):
     node_groups: Dict[str, AWSNodeGroup] = DEFAULT_AWS_NODE_GROUPS
     eks_endpoint_access: Optional[
         Literal["private", "public", "public_and_private"]
-    ] = "public"
+    ] = "public_and_private"
     eks_public_access_cidrs: Optional[List[str]] = ["0.0.0.0/0"]
     eks_kms_arn: Optional[str] = None
     existing_subnet_ids: Optional[List[str]] = None

--- a/src/_nebari/stages/infrastructure/template/aws/modules/network/main.tf
+++ b/src/_nebari/stages/infrastructure/template/aws/modules/network/main.tf
@@ -7,15 +7,30 @@ resource "aws_vpc" "main" {
   tags = merge({ Name = var.name }, var.tags, var.vpc_tags)
 }
 
-resource "aws_subnet" "main" {
+resource "aws_subnet" "public" {
   count = length(var.aws_availability_zones)
 
-  availability_zone       = var.aws_availability_zones[count.index]
-  cidr_block              = cidrsubnet(var.vpc_cidr_block, var.vpc_cidr_newbits, count.index)
-  vpc_id                  = aws_vpc.main.id
-  map_public_ip_on_launch = true
+  availability_zone = var.aws_availability_zones[count.index]
+  cidr_block        = cidrsubnet(var.vpc_cidr_block, var.vpc_cidr_newbits, count.index)
+  vpc_id            = aws_vpc.main.id
 
-  tags = merge({ Name = "${var.name}-subnet-${count.index}" }, var.tags, var.subnet_tags)
+  tags = merge({ Name = "${var.name}-pulbic-subnet-${count.index}", "kubernetes.io/role/elb" = 1 }, var.tags, var.subnet_tags)
+
+  lifecycle {
+    ignore_changes = [
+      availability_zone
+    ]
+  }
+}
+
+resource "aws_subnet" "private" {
+  count = length(var.aws_availability_zones)
+
+  availability_zone = var.aws_availability_zones[count.index]
+  cidr_block        = cidrsubnet(var.vpc_cidr_block, var.vpc_cidr_newbits, count.index + length(var.aws_availability_zones))
+  vpc_id            = aws_vpc.main.id
+
+  tags = merge({ Name = "${var.name}-private-subnet-${count.index}" }, var.tags, var.subnet_tags)
 
   lifecycle {
     ignore_changes = [
@@ -30,7 +45,25 @@ resource "aws_internet_gateway" "main" {
   tags = merge({ Name = var.name }, var.tags)
 }
 
-resource "aws_route_table" "main" {
+resource "aws_eip" "nat-gateway-eip" {
+  count = length(var.aws_availability_zones)
+
+  domain = "vpc"
+
+  tags = merge({ Name = "${var.name}-nat-gateway-eip-${count.index}" }, var.tags)
+}
+
+resource "aws_nat_gateway" "main" {
+  count = length(var.aws_availability_zones)
+
+  allocation_id = aws_eip.nat-gateway-eip[count.index].id
+  subnet_id     = aws_subnet.public[count.index].id
+
+  tags       = merge({ Name = "${var.name}-nat-gateway-${count.index}" }, var.tags)
+  depends_on = [aws_internet_gateway.main]
+}
+
+resource "aws_route_table" "public" {
   vpc_id = aws_vpc.main.id
 
   route {
@@ -41,11 +74,31 @@ resource "aws_route_table" "main" {
   tags = merge({ Name = var.name }, var.tags)
 }
 
-resource "aws_route_table_association" "main" {
+resource "aws_route_table" "private" {
   count = length(var.aws_availability_zones)
 
-  subnet_id      = aws_subnet.main[count.index].id
-  route_table_id = aws_route_table.main.id
+  vpc_id = aws_vpc.main.id
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_nat_gateway.main[count.index].id
+  }
+
+  tags = merge({ Name = var.name }, var.tags)
+}
+
+resource "aws_route_table_association" "public" {
+  count = length(var.aws_availability_zones)
+
+  subnet_id      = aws_subnet.public[count.index].id
+  route_table_id = aws_route_table.public.id
+}
+
+resource "aws_route_table_association" "private" {
+  count = length(var.aws_availability_zones)
+
+  subnet_id      = aws_subnet.private[count.index].id
+  route_table_id = aws_route_table.private[count.index].id
 }
 
 resource "aws_security_group" "main" {
@@ -62,7 +115,6 @@ resource "aws_security_group" "main" {
     cidr_blocks = [var.vpc_cidr_block]
   }
 
-  #trivy:ignore:AVD-AWS-0104
   egress {
     description = "Allow all ports and protocols to exit the security group"
     from_port   = 0
@@ -72,4 +124,62 @@ resource "aws_security_group" "main" {
   }
 
   tags = merge({ Name = var.name }, var.tags, var.security_group_tags)
+}
+
+resource "aws_vpc_endpoint" "s3" {
+  vpc_id            = aws_vpc.main.id
+  service_name      = "com.amazonaws.${var.region}.s3"
+  vpc_endpoint_type = "Gateway"
+  route_table_ids   = aws_route_table.private[*].id
+  tags              = merge({ Name = "${var.name}-s3-endpoint" }, var.tags)
+}
+
+resource "aws_vpc_endpoint" "ecr_api" {
+  vpc_id              = aws_vpc.main.id
+  service_name        = "com.amazonaws.${var.region}.ecr.api"
+  vpc_endpoint_type   = "Interface"
+  private_dns_enabled = true
+  security_group_ids  = [aws_security_group.main.id]
+  subnet_ids          = aws_subnet.private[*].id
+  tags                = merge({ Name = "${var.name}-ecr-api-endpoint" }, var.tags)
+}
+
+resource "aws_vpc_endpoint" "ecr_dkr" {
+  vpc_id              = aws_vpc.main.id
+  service_name        = "com.amazonaws.${var.region}.ecr.dkr"
+  vpc_endpoint_type   = "Interface"
+  private_dns_enabled = true
+  security_group_ids  = [aws_security_group.main.id]
+  subnet_ids          = aws_subnet.private[*].id
+  tags                = merge({ Name = "${var.name}-ecr-dkr-endpoint" }, var.tags)
+}
+
+resource "aws_vpc_endpoint" "elasticloadbalancing" {
+  vpc_id              = aws_vpc.main.id
+  service_name        = "com.amazonaws.${var.region}.elasticloadbalancing"
+  vpc_endpoint_type   = "Interface"
+  private_dns_enabled = true
+  security_group_ids  = [aws_security_group.main.id]
+  subnet_ids          = aws_subnet.private[*].id
+  tags                = merge({ Name = "${var.name}-elb-endpoint" }, var.tags)
+}
+
+resource "aws_vpc_endpoint" "sts" {
+  vpc_id              = aws_vpc.main.id
+  service_name        = "com.amazonaws.${var.region}.sts"
+  vpc_endpoint_type   = "Interface"
+  private_dns_enabled = true
+  security_group_ids  = [aws_security_group.main.id]
+  subnet_ids          = aws_subnet.private[*].id
+  tags                = merge({ Name = "${var.name}-sts-endpoint" }, var.tags)
+}
+
+resource "aws_vpc_endpoint" "eks" {
+  vpc_id              = aws_vpc.main.id
+  service_name        = "com.amazonaws.${var.region}.eks"
+  vpc_endpoint_type   = "Interface"
+  private_dns_enabled = true
+  security_group_ids  = [aws_security_group.main.id]
+  subnet_ids          = aws_subnet.private[*].id
+  tags                = merge({ Name = "${var.name}-eks-endpoint" }, var.tags)
 }

--- a/src/_nebari/stages/infrastructure/template/aws/modules/network/outputs.tf
+++ b/src/_nebari/stages/infrastructure/template/aws/modules/network/outputs.tf
@@ -3,9 +3,14 @@ output "security_group_id" {
   value       = aws_security_group.main.id
 }
 
-output "subnet_ids" {
-  description = "AWS VPC subnet ids"
-  value       = aws_subnet.main[*].id
+output "public_subnet_ids" {
+  description = "AWS VPC public subnet ids"
+  value       = aws_subnet.public[*].id
+}
+
+output "private_subnet_ids" {
+  description = "AWS VPC private subnet ids"
+  value       = aws_subnet.private[*].id
 }
 
 output "vpc_id" {

--- a/src/_nebari/stages/infrastructure/template/aws/modules/network/variables.tf
+++ b/src/_nebari/stages/infrastructure/template/aws/modules/network/variables.tf
@@ -40,5 +40,11 @@ variable "vpc_cidr_block" {
 variable "vpc_cidr_newbits" {
   description = "VPC cidr number of bits to support 2^N subnets"
   type        = number
-  default     = 2
+  default     = 4 # allows 16 /20 subnets with 4094 addresses each
+}
+
+variable "region" {
+  description = "AWS region to operate infrastructure"
+  type        = string
+
 }


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://nebari.dev/community
-->

## Reference Issues or PRs
Closes #2952 
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create a link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

## What does this implement/fix?
Moves nodes to private subnets and removes the autoassign public IP option. 

Currently our nodes are placed in public subnets with a public ip assigned by default. This is a security vulnerability that gives us no benefit whatsoever. The new setup places all nodes in a private subnet while keeping load balancers in public subnets. This will still allow public access to nebari, but you will not be able to access the nodes themselves over the public internet anymore.

The following illustration is from the AWS documentation (https://docs.aws.amazon.com/eks/latest/best-practices/subnets.html) and shows the new setup. Note that this is the recommended setup for EKS on AWS.

![image](https://github.com/user-attachments/assets/7efeb7b0-1052-4c47-a072-d6ef3ccec7ed)

 
_Put a `x` in the boxes that apply_

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds a feature)
- [ ] Breaking change (fix or feature that would cause existing features not to work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Other (please describe):

## Testing

- [X] Did you test the pull request locally?
- [ ] Did you add new tests?

## How to test this PR?

Deploy Nebari to AWS, in the console validate that the nodes are located in Private subnets, then go through the testing checklist to validate all functionality is unchanged.

<!--
If relevant, please outline the steps required to test your contribution
and the expected outcomes from the proposed changes. Providing clear
testing instructions will help reviewers evaluate your contribution.
-->

## Any other comments?

**NOTE** This will likely result in issues with the general node not restarting if it ends up in a different AZ from it's EBS volume. This is a known issue and needs addressed by changing our storage setup.

<!--
Please be aware that we are a loose team of volunteers, so patience is necessary;
assistance handling other issues is very welcome.
We value all user contributions. If we are slow to review, either the pull request needs some benchmarking, tinkering,
convincing, etc., or the reviewers are likely busy. In either case,
we ask for your understanding during the
review process.
Thanks for contributing to Nebari 🙏🏼!
-->
