### PR TITLE
Pin conda-lock < 3.0.0 to fix conda-store user journey test failures

### DIFF
--- a/.github/workflows/test_local_integration.yaml
+++ b/.github/workflows/test_local_integration.yaml
@@ -179,6 +179,7 @@ jobs:
         run: |
           which python
           # install conda-store-server
+          python -m pip install "conda-lock>=1.0.5,<3.0.0"  # Added until https://github.com/conda-incubator/conda-store/issues/1095 is solved upstream
           python -m pip install conda-store/conda-store-server
 
       - name: Get conda store token from login

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,7 @@ dependencies = [
     "bcrypt==4.0.1",
     "boto3==1.34.63",
     "cloudflare==2.11.7",
+    "conda-lock >=1.0.5,<3.0.0",  # Added until https://github.com/conda-incubator/conda-store/issues/1095 is solved upstream
     "google-auth>=2.31.0,<3.0.0",
     "google-cloud-compute==1.19.1",
     "google-cloud-container==2.49.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,6 @@ dependencies = [
     "bcrypt==4.0.1",
     "boto3==1.34.63",
     "cloudflare==2.11.7",
-    "conda-lock >=1.0.5,<3.0.0",  # Added until https://github.com/conda-incubator/conda-store/issues/1095 is solved upstream
     "google-auth>=2.31.0,<3.0.0",
     "google-cloud-compute==1.19.1",
     "google-cloud-container==2.49.0",


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://nebari.dev/community
-->

## Reference Issues or PRs

Fixes https://github.com/conda-incubator/conda-store/issues/1095 temporarily in Nebari

<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create a link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

## What does this implement/fix?

_Put a `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds a feature)
- [ ] Breaking change (fix or feature that would cause existing features not to work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Other (please describe):

## Documentation

- [ ] For new features or enhancements, a corresponding PR has been opened in the [documentation repository](https://github.com/nebari-dev/nebari-docs) (if applicable)
  - Link to docs PR:

## Testing

- [ ] Did you test the pull request locally?
- [ ] Did you add new tests?

## How to test this PR?

Make sure the conda-store user journey tests step in the local integration tests workflow are passing

<!--
If relevant, please outline the steps required to test your contribution
and the expected outcomes from the proposed changes. Providing clear
testing instructions will help reviewers evaluate your contribution.
-->

## Any other comments?

<!--
Please be aware that we are a loose team of volunteers, so patience is necessary;
assistance handling other issues is very welcome.
We value all user contributions. If we are slow to review, either the pull request needs some benchmarking, tinkering,
convincing, etc., or the reviewers are likely busy. In either case,
we ask for your understanding during the
review process.
Thanks for contributing to Nebari 🙏🏼!
-->
