### PR TITLE
Revert aks cluster argument to auto_scaling_enabled

### DIFF
--- a/src/_nebari/stages/infrastructure/template/azure/modules/kubernetes/main.tf
+++ b/src/_nebari/stages/infrastructure/template/azure/modules/kubernetes/main.tf
@@ -34,13 +34,13 @@ resource "azurerm_kubernetes_cluster" "main" {
 
   kubernetes_version = var.kubernetes_version
   default_node_pool {
-    vnet_subnet_id      = var.vnet_subnet_id
-    name                = var.node_groups[0].name
-    vm_size             = var.node_groups[0].instance_type
-    enable_auto_scaling = "true"
-    min_count           = var.node_groups[0].min_size
-    max_count           = var.node_groups[0].max_size
-    max_pods            = var.max_pods
+    vnet_subnet_id       = var.vnet_subnet_id
+    name                 = var.node_groups[0].name
+    vm_size              = var.node_groups[0].instance_type
+    auto_scaling_enabled = "true"
+    min_count            = var.node_groups[0].min_size
+    max_count            = var.node_groups[0].max_size
+    max_pods             = var.max_pods
     # It's not possible to add node_taints to the default node pool. See https://github.com/hashicorp/terraform-provider-azurerm/issues/9183 for more info
 
     orchestrator_version = var.kubernetes_version


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://nebari.dev/community
-->

## Reference Issues or PRs
Closes #3021 

<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create a link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

## What does this implement/fix?

_Put a `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds a feature)
- [ ] Breaking change (fix or feature that would cause existing features not to work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Other (please describe):

## Documentation

- [ ] For new features or enhancements, a corresponding PR has been opened in the [documentation repository](https://github.com/nebari-dev/nebari-docs) (if applicable)
  - Link to docs PR:

## Testing

- [ ] Did you test the pull request locally?
- [ ] Did you add new tests?

## How to test this PR?

Deploy Nebari to Azure and make sure it does not fail with:
```
[tofu]: │ Error: Unsupported argument
[tofu]: │ 
[tofu]: │   on modules/kubernetes/main.tf line 40, in resource "azurerm_kubernetes_cluster" "main":
[tofu]: │   40:     enable_auto_scaling = "true"
[tofu]: │ 
[tofu]: │ An argument named "enable_auto_scaling" is not expected here.
[tofu]: ╵
```

<!--
If relevant, please outline the steps required to test your contribution
and the expected outcomes from the proposed changes. Providing clear
testing instructions will help reviewers evaluate your contribution.
-->

## Any other comments?

<!--
Please be aware that we are a loose team of volunteers, so patience is necessary;
assistance handling other issues is very welcome.
We value all user contributions. If we are slow to review, either the pull request needs some benchmarking, tinkering,
convincing, etc., or the reviewers are likely busy. In either case,
we ask for your understanding during the
review process.
Thanks for contributing to Nebari 🙏🏼!
-->
