### PR TITLE
Update usage of `create_user` within pytest fixture call

### DIFF
--- a/tests/tests_integration/deployment_fixtures.py
+++ b/tests/tests_integration/deployment_fixtures.py
@@ -80,11 +80,10 @@ def _set_nebari_creds_in_environment(config):
 def _create_nebari_user(config):
     import keycloak
 
-    from _nebari.keycloak import create_user, get_keycloak_admin_from_config
+    from _nebari.keycloak import create_user
 
-    keycloak_admin = get_keycloak_admin_from_config(config)
     try:
-        user = create_user(keycloak_admin, "pytest", "pytest-password")
+        user = create_user(config, username="pytest", password="pytest-password")
         return user
     except keycloak.KeycloakPostError as e:
         if e.response_code == 409:


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://nebari.dev/community
-->

## Reference Issues or PRs

<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create a link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

## What does this implement/fix?

With the changes introduced by #2968, there is no need to supply the keycloak admin class to create_user or any of its auxiliary methods since that is now handled internally by the `dp_keycloak` wrapper; only the nebari config schema object needs to be supplied. 

_Put a `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds a feature)
- [ ] Breaking change (fix or feature that would cause existing features not to work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Other (please describe):

## Documentation

- [ ] For new features or enhancements, a corresponding PR has been opened in the [documentation repository](https://github.com/nebari-dev/nebari-docs) (if applicable)
  - Link to docs PR:

## Testing

- [ ] Did you test the pull request locally?
- [ ] Did you add new tests?

## How to test this PR?

<!--
If relevant, please outline the steps required to test your contribution
and the expected outcomes from the proposed changes. Providing clear
testing instructions will help reviewers evaluate your contribution.
-->

## Any other comments?

<!--
Please be aware that we are a loose team of volunteers, so patience is necessary;
assistance handling other issues is very welcome.
We value all user contributions. If we are slow to review, either the pull request needs some benchmarking, tinkering,
convincing, etc., or the reviewers are likely busy. In either case,
we ask for your understanding during the
review process.
Thanks for contributing to Nebari 🙏🏼!
-->
