### PR TITLE
Change JupyterLab default windowing mode to defer

### DIFF
--- a/src/_nebari/stages/kubernetes_services/template/modules/kubernetes/services/jupyterhub/files/jupyterlab/overrides.json
+++ b/src/_nebari/stages/kubernetes_services/template/modules/kubernetes/services/jupyterhub/files/jupyterlab/overrides.json
@@ -122,5 +122,8 @@
                 ]
             }
         ]
+    },
+    "@jupyterlab/notebook-extension:tracker" : {
+        "windowingMode": "defer"
     }
 }


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://nebari.dev/community
-->

## Reference Issues or PRs
Companion PR: https://github.com/nebari-dev/nebari-docker-images/pull/219

<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create a link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

## What does this implement/fix?

_Put a `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds a feature)
- [ ] Breaking change (fix or feature that would cause existing features not to work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [x] Other (please describe): Changes the windowing mode in the default JupyterLab configuration

## Documentation

- [ ] For new features or enhancements, a corresponding PR has been opened in the [documentation repository](https://github.com/nebari-dev/nebari-docs) (if applicable)
  - Link to docs PR:

## Testing

- [ ] Did you test the pull request locally?
- [ ] Did you add new tests?

## How to test this PR?
Deploy Nebari from this branch using the JupyterLab image built by https://github.com/nebari-dev/nebari-docker-images/pull/219. Specify it in the Nebari config file as follows:
```yaml
default_images:
  jupyterlab: quay.io/nebari/nebari-jupyterlab:upgrade-jupyterlab-c84ace5-20250516
```

Once Nebari is deployed, spawn a JupyterLab server, go to the Settings tab, and open the Settings Editor. Navigate to the Notebook section on the left panel, click on the JSOn Settings Editor Button on the upper right corner, and make sure `"windowingMode": "defer"` is on the System Defaults JSON, just like this:

<img width="1342" alt="image" src="https://github.com/user-attachments/assets/d3424293-62ec-49aa-95fe-ba014862835f" />

<!--
If relevant, please outline the steps required to test your contribution
and the expected outcomes from the proposed changes. Providing clear
testing instructions will help reviewers evaluate your contribution.
-->

## Any other comments?

<!--
Please be aware that we are a loose team of volunteers, so patience is necessary;
assistance handling other issues is very welcome.
We value all user contributions. If we are slow to review, either the pull request needs some benchmarking, tinkering,
convincing, etc., or the reviewers are likely busy. In either case,
we ask for your understanding during the
review process.
Thanks for contributing to Nebari 🙏🏼!
-->
