### PR TITLE
Add missing toleration to aws_nvidia_installer DaemonSet to support tainted GPU nodes

### DIFF
--- a/src/_nebari/stages/kubernetes_initialize/__init__.py
+++ b/src/_nebari/stages/kubernetes_initialize/__init__.py
@@ -89,7 +89,9 @@ class KubernetesInitializeStage(NebariTerraformStage):
                 for node_group in self.config.amazon_web_services.node_groups.values()
             )
             input_vars.gpu_node_group_names = [
-                group for group in self.config.amazon_web_services.node_groups.keys()
+                group
+                for group in self.config.amazon_web_services.node_groups.keys()
+                if self.config.amazon_web_services.node_groups[group].gpu
             ]
             input_vars.aws_region = self.config.amazon_web_services.region
 

--- a/src/_nebari/stages/kubernetes_initialize/template/modules/nvidia-installer/aws-nvidia-installer.tf
+++ b/src/_nebari/stages/kubernetes_initialize/template/modules/nvidia-installer/aws-nvidia-installer.tf
@@ -68,6 +68,13 @@ resource "kubernetes_daemonset" "aws_nvidia_installer" {
           operator = "Exists"
           effect   = "NoSchedule"
         }
+
+        toleration {
+          key      = "dedicated"
+          operator = "Equal"
+          value    = "nebari"
+          effect   = "NoSchedule"
+        }
       }
     }
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://nebari.dev/community
-->

## Reference Issues or PRs

<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create a link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

Closes #3074 

## What does this implement/fix?

_Put a `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds a feature)
- [ ] Breaking change (fix or feature that would cause existing features not to work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Other (please describe):

## Documentation

- [ ] For new features or enhancements, a corresponding PR has been opened in the [documentation repository](https://github.com/nebari-dev/nebari-docs) (if applicable)
  - Link to docs PR:

## Testing

- [x] Did you test the pull request locally?
- [ ] Did you add new tests?

## How to test this PR?

<!--
If relevant, please outline the steps required to test your contribution
and the expected outcomes from the proposed changes. Providing clear
testing instructions will help reviewers evaluate your contribution.
-->

1. Deploy Nebari off [this branch](https://github.com/nebari-dev/nebari/tree/add-aws-nvidia-installer-toleration) to AWS, using the following node group configuration:
```yaml
# ...
amazon_web_services:
  # ...
  node_groups:
    # ...
    gpu-t4-x1:
      instance: g4dn.xlarge
      min_nodes: 0
      max_nodes: 5
      gpu: true
profiles:
  jupyterlab:
  - display_name: T4 GPU Instance
    description: Stable environment with 4 cpu / 16 GB ram and 1 T4 GPU / 16 GB GPU memory
    kubespawner_override:
      cpu_limit: 4
      cpu_guarantee: 3
      mem_limit: 16G
      mem_guarantee: 10G
      extra_resource_limits:
        nvidia.com/gpu: 1
      image: quay.io/nebari/nebari-jupyterlab-gpu:2025.6.1
      node_selector:
        "dedicated": "gpu-t4-x1"
```
2. Launch a JupyterLab server with the T4 GPU instance profile (and wait for it to be available)
3. Run the following command from a terminal with access to the cluster:
```bash
kubectl get nodes "-o=custom-columns=NAME:.metadata.name,GPU:.status.allocatable.nvidia\.com/gpu"
```

The output will look like this:
```
NAME                                         GPU
ip-10-10-2-41.us-west-2.compute.internal     1  # Hurray!
ip-10-10-30-220.us-west-2.compute.internal   <none>  # This is the general node, so no GPU expected
```

4. From a terminal in the JupyterLab server, run the following command:
```bash
nvidia-smi
```

The output should look like:
```
12:20 $ nvidia-smi
Thu Jun 19 12:20:22 2025       
+-----------------------------------------------------------------------------------------+
| NVIDIA-SMI 550.163.01             Driver Version: 550.163.01     CUDA Version: 12.4     |
|-----------------------------------------+------------------------+----------------------+
| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
|                                         |                        |               MIG M. |
|=========================================+========================+======================|
|   0  Tesla T4                       On  |   00000000:00:1E.0 Off |                    0 |
| N/A   26C    P8             11W /   70W |       1MiB /  15360MiB |      0%      Default |
|                                         |                        |                  N/A |
+-----------------------------------------+------------------------+----------------------+
                                                                                         
+-----------------------------------------------------------------------------------------+
| Processes:                                                                              |
|  GPU   GI   CI        PID   Type   Process name                              GPU Memory |
|        ID   ID                                                               Usage      |
|=========================================================================================|
|  No running processes found                                                             |
+-----------------------------------------------------------------------------------------+
```



## Any other comments?

<!--
Please be aware that we are a loose team of volunteers, so patience is necessary;
assistance handling other issues is very welcome.
We value all user contributions. If we are slow to review, either the pull request needs some benchmarking, tinkering,
convincing, etc., or the reviewers are likely busy. In either case,
we ask for your understanding during the
review process.
Thanks for contributing to Nebari 🙏🏼!
-->
