### PR TITLE
allow passing default attr to dask worker profiles

### DIFF
--- a/src/_nebari/stages/kubernetes_services/__init__.py
+++ b/src/_nebari/stages/kubernetes_services/__init__.py
@@ -178,6 +178,7 @@ class DaskWorkerProfile(schema.Base):
     worker_memory: str
     worker_threads: int = 1
     model_config = ConfigDict(extra="allow")
+    default: bool = False
 
 
 class Profiles(schema.Base):
@@ -230,6 +231,17 @@ class Profiles(schema.Base):
             raise TypeError(
                 "Multiple default Jupyterlab profiles may cause unexpected problems."
             )
+        return value
+
+    @field_validator("dask_worker")
+    @classmethod
+    def assert_single_default_dask(cls, value):
+        """
+        Check if only one default value is present in the dask profiles
+        """
+        default = [attrs["default"] for attrs in value if "default" in attrs]
+        if default.count(True) > 1:
+            raise TypeError("Multiple default Dask worker profiles are not supported.")
         return value
 
 

--- a/src/_nebari/stages/kubernetes_services/template/modules/kubernetes/services/dask-gateway/files/gateway_config.py
+++ b/src/_nebari/stages/kubernetes_services/template/modules/kubernetes/services/dask-gateway/files/gateway_config.py
@@ -261,6 +261,14 @@ def user_options(user):
             continue
         conda_environments.append(f"{namespace}/{namespace}-{name}")
 
+    def parse_default_profile(profiles: dict):
+        profiles_keys = profiles.keys()
+        for profile in profiles_keys:
+            if profiles[profile].get("default", False):
+                return profile
+            continue
+        return list(profiles_keys)[0]
+
     args = []
     if conda_environments:
         args += [
@@ -276,7 +284,7 @@ def user_options(user):
             Select(
                 "profile",
                 list(config["profiles"].keys()),
-                default=list(config["profiles"].keys())[0],
+                default=parse_default_profile(config["profiles"]),
                 label="Cluster Profile",
             )
         ]


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://nebari.dev/community
-->

## Reference Issues or PRs
closes #3087 

<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create a link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

## What does this implement/fix?

_Put a `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds a feature)
- [ ] Breaking change (fix or feature that would cause existing features not to work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Other (please describe):

## Documentation

- [ ] For new features or enhancements, a corresponding PR has been opened in the [documentation repository](https://github.com/nebari-dev/nebari-docs) (if applicable)
  - Link to docs PR:

## Testing

- [ ] Did you test the pull request locally?
- [ ] Did you add new tests?

## How to test this PR?

<!--
If relevant, please outline the steps required to test your contribution
and the expected outcomes from the proposed changes. Providing clear
testing instructions will help reviewers evaluate your contribution.
-->

## Any other comments?

<!--
Please be aware that we are a loose team of volunteers, so patience is necessary;
assistance handling other issues is very welcome.
We value all user contributions. If we are slow to review, either the pull request needs some benchmarking, tinkering,
convincing, etc., or the reviewers are likely busy. In either case,
we ask for your understanding during the
review process.
Thanks for contributing to Nebari 🙏🏼!
-->
