### PR TITLE
Suppress missing GID warnings with supplemental groups

### DIFF
--- a/src/_nebari/stages/kubernetes_services/template/modules/kubernetes/services/jupyterhub/files/jupyterhub/03-profiles.py
+++ b/src/_nebari/stages/kubernetes_services/template/modules/kubernetes/services/jupyterhub/files/jupyterhub/03-profiles.py
@@ -357,9 +357,17 @@ def configure_user(username, groups, uid=1000, gid=100):
         "PIP_REQUIRE_VIRTUALENV": "true",
     }
 
+    # Map supplemental GIDs to dummy group names to suppress 'missing GID'
+    #  warnings at startup. This is a temporary workaround; see issue #3044
+    # for context and planned improvements.
+    additional_gids = [4, 20, 24, 25, 27, 29, 30, 44, 46]
+    group_entries = [{"groupname": "users", "gid": gid}] + [
+        {"groupname": f"nogroup{g}", "gid": g} for g in additional_gids
+    ]
+
     etc_passwd, etc_group = generate_nss_files(
         users=[{"username": username, "uid": uid, "gid": gid}],
-        groups=[{"groupname": "users", "gid": gid}],
+        groups=group_entries,
     )
 
     jupyter_config = json.dumps(


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://nebari.dev/community
-->

## Reference Issues or PRs

relates as a workaround for #3044 

<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create a link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

## What does this implement/fix?

This PR includes a list of supplemental group IDs (GIDs) to the NSS wrapper group files to dismiss the:
```shell
groups: cannot find name for group ID XX
```
Warning logs during terminal/kernel startups on users' JupyterLab instances. 

_Put a `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds a feature)
- [ ] Breaking change (fix or feature that would cause existing features not to work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Other (please describe):

## Documentation

- [ ] For new features or enhancements, a corresponding PR has been opened in the [documentation repository](https://github.com/nebari-dev/nebari-docs) (if applicable)
  - Link to docs PR:

## Testing

- [ ] Did you test the pull request locally?
- [ ] Did you add new tests?

## How to test this PR?

<!--
If relevant, please outline the steps required to test your contribution
and the expected outcomes from the proposed changes. Providing clear
testing instructions will help reviewers evaluate your contribution.
-->

## Any other comments?

<!--
Please be aware that we are a loose team of volunteers, so patience is necessary;
assistance handling other issues is very welcome.
We value all user contributions. If we are slow to review, either the pull request needs some benchmarking, tinkering,
convincing, etc., or the reviewers are likely busy. In either case,
we ask for your understanding during the
review process.
Thanks for contributing to Nebari 🙏🏼!
-->
