### PR TITLE
Update cirun AMI to ami-00b0b011acb78247b

### DIFF
--- a/.cirun.yml
+++ b/.cirun.yml
@@ -7,7 +7,7 @@ runners:
     # Instance Type has 8 vcpu, 32 GiB memory, Up to 5 Gbps Network Performance
     instance_type: t3a.2xlarge
     # Custom Ubuntu 24.04 AMI with docker/hub pre-installed
-    machine_image: ami-01b494943951b97c7
+    machine_image: ami-00b0b011acb78247b
     # Region: Oregon
     region: us-west-2
     # Use Spot Instances for cost savings


### PR DESCRIPTION
## 🚀 AMI Update

This PR updates the cirun.io AMI configuration with a newly built AMI.

**Changes:**
- **Previous AMI:** `ami-00b0b011acb78247b`
- **New AMI:** `ami-00b0b011acb78247b`
- **AMI Name:** `nebari-cirun-runner-ubuntu24-20250716-1052`
- **Created:** `2025-07-16T11:02:19.000Z`
- **Description:** `No description available`

**Base Configuration:**
- Ubuntu 24.04 LTS (us-west-2)
- 100GB gp3 storage with 6,000 IOPS and 250 MB/s throughput
- Automatic system updates disabled for CI stability

**Pre-installed Tools:**
- Docker & Docker Compose
- Kubernetes tools (kubectl, kind, k9s)
- Node.js 20 & npm
- Miniconda (latest)
- Playwright (via pipx)
- AWS CLI v2
- Common utilities (jq, hub, git, curl, wget)

---
🤖 Generated automatically by [nebari-ci](https://github.com/nebari-dev/nebari-ci)