### PR TITLE
Update cirun AMI to `ami-028b291f28c6529f7`

### DIFF
--- a/.cirun.yml
+++ b/.cirun.yml
@@ -7,7 +7,7 @@ runners:
     # Instance Type has 8 vcpu, 32 GiB memory, Up to 5 Gbps Network Performance
     instance_type: t3a.2xlarge
     # Custom Ubuntu 24.04 AMI with docker/hub pre-installed
-    machine_image: ami-01b494943951b97c7
+    machine_image: ami-028b291f28c6529f7
     # Region: Oregon
     region: us-west-2
     # Use Spot Instances for cost savings


### PR DESCRIPTION
## 🚀 AMI Update

This PR updates the cirun.io AMI configuration with a newly built AMI.

**Changes:**
- **Previous AMI:** `ami-01b494943951b97c7`
- **New AMI:** `ami-028b291f28c6529f7`
- **AMI Name:** `nebari-cirun-runner-ubuntu24-20250716-1241`
- **Created:** `2025-07-16T12:50:53.000Z`
- **Description:** `No description available`
- **Build Job:** [https://github.com/nebari-dev/nebari-ci/actions/runs/16319738252](https://github.com/nebari-dev/nebari-ci/actions/runs/16319738252)
- **Commit Hash:** [`88e812a25bd465de1e18669e3b2cba7f7f8137b9`](https://github.com/nebari-dev/nebari-ci/commit/88e812a25bd465de1e18669e3b2cba7f7f8137b9)

**Base Configuration:**
- Ubuntu 24.04 LTS (us-west-2)
- 100GB gp3 storage with 6,000 IOPS and 250 MB/s throughput
- Automatic system updates disabled for CI stability

**Pre-installed Tools:**
- Docker & Docker Compose
- Kubernetes tools (kubectl, kind, k9s)
- Node.js 20 & npm
- Miniconda (latest)
- Playwright (via pipx)
- AWS CLI v2
- Common utilities (jq, hub, git, curl, wget)

---
🤖 Generated automatically by [nebari-ci](https://github.com/nebari-dev/nebari-ci)