### PR TITLE
Remove --output/-o for now, it is not safe

### DIFF
--- a/src/_nebari/subcommands/deploy.py
+++ b/src/_nebari/subcommands/deploy.py
@@ -23,12 +23,14 @@ def nebari_subcommand(cli: typer.Typer):
             "-c",
             help="nebari configuration yaml file path",
         ),
-        output_directory: pathlib.Path = typer.Option(
-            "./",
-            "-o",
-            "--output",
-            help="output directory",
-        ),
+        # TODO: Remove -o/--output argument until it is safe to use
+        # See: https://github.com/nebari-dev/nebari/issues/1716
+        # output_directory: pathlib.Path = typer.Option(
+        #     "./",
+        #     "-o",
+        #     "--output",
+        #     help="output directory",
+        # ),
         dns_provider: Optional[str] = typer.Option(
             None,
             "--dns-provider",
@@ -76,7 +78,8 @@ def nebari_subcommand(cli: typer.Typer):
         config = read_configuration(config_filename, config_schema=config_schema)
 
         if not disable_render:
-            render_template(output_directory, config, stages)
+            # Use hardcoded "./" since output_directory parameter was removed
+            render_template("./", config, stages)
 
         if skip_remote_state_provision:
             for stage in stages:

--- a/src/_nebari/subcommands/destroy.py
+++ b/src/_nebari/subcommands/destroy.py
@@ -16,12 +16,14 @@ def nebari_subcommand(cli: typer.Typer):
         config_filename: pathlib.Path = typer.Option(
             ..., "-c", "--config", help="nebari configuration file path"
         ),
-        output_directory: pathlib.Path = typer.Option(
-            "./",
-            "-o",
-            "--output",
-            help="output directory",
-        ),
+        # TODO: Remove -o/--output argument until it is safe to use
+        # See: https://github.com/nebari-dev/nebari/issues/1716
+        # output_directory: pathlib.Path = typer.Option(
+        #     "./",
+        #     "-o",
+        #     "--output",
+        #     help="output directory",
+        # ),
         disable_render: bool = typer.Option(
             False,
             "--disable-render",
@@ -47,7 +49,8 @@ def nebari_subcommand(cli: typer.Typer):
             config = read_configuration(config_filename, config_schema=config_schema)
 
             if not disable_render:
-                render_template(output_directory, config, stages)
+                # Use hardcoded "./" since output_directory parameter was removed
+                render_template("./", config, stages)
 
             destroy_configuration(config, stages)
 

--- a/src/_nebari/subcommands/render.py
+++ b/src/_nebari/subcommands/render.py
@@ -12,12 +12,14 @@ def nebari_subcommand(cli: typer.Typer):
     @cli.command(rich_help_panel="Additional Commands")
     def render(
         ctx: typer.Context,
-        output_directory: pathlib.Path = typer.Option(
-            "./",
-            "-o",
-            "--output",
-            help="output directory",
-        ),
+        # TODO: Remove -o/--output argument until it is safe to use
+        # See: https://github.com/nebari-dev/nebari/issues/1716
+        # output_directory: pathlib.Path = typer.Option(
+        #     "./",
+        #     "-o",
+        #     "--output",
+        #     help="output directory",
+        # ),
         config_filename: pathlib.Path = typer.Option(
             ...,
             "-c",
@@ -39,4 +41,5 @@ def nebari_subcommand(cli: typer.Typer):
         config_schema = nebari_plugin_manager.config_schema
 
         config = read_configuration(config_filename, config_schema=config_schema)
-        render_template(output_directory, config, stages, dry_run=dry_run)
+        # Use hardcoded "./" since output_directory parameter was removed
+        render_template("./", config, stages, dry_run=dry_run)


### PR DESCRIPTION
Safety issue: https://github.com/nebari-dev/nebari/issues/1716

Until that issue is fixed and tested, IMO it is best to temporarily remove this feature.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds a feature)
- [ ] Breaking change (fix or feature that would cause existing features not to work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Other (please describe):

## Testing

- [X] Did you test the pull request locally?
- [ ] Did you add new tests?


