### PR TITLE
bf: do not clobber existing .gitignore

### DIFF
--- a/src/_nebari/stages/bootstrap/__init__.py
+++ b/src/_nebari/stages/bootstrap/__init__.py
@@ -13,9 +13,14 @@ from nebari.hookspecs import NebariStage, hookimpl
 
 def gen_gitignore():
     """
-    Generate `.gitignore` file.
-    Add files as needed.
+    Generate `.gitignore` file if not present.
     """
+    gitignore_path = pathlib.Path(".gitignore")
+
+    # If .gitignore already exists, don't overwrite it
+    if gitignore_path.exists():
+        return {}
+
     filestoignore = """
         # ignore terraform state
         .terraform
@@ -26,7 +31,7 @@ def gen_gitignore():
         # python
         __pycache__
     """
-    return {pathlib.Path(".gitignore"): cleandoc(filestoignore)}
+    return {gitignore_path: cleandoc(filestoignore)}
 
 
 def gen_cicd(config: schema.Main):

--- a/tests/tests_unit/conftest.py
+++ b/tests/tests_unit/conftest.py
@@ -1,3 +1,4 @@
+import os
 from pathlib import Path
 from unittest.mock import Mock
 
@@ -182,10 +183,19 @@ def nebari_stages():
 def nebari_render(nebari_config, nebari_stages, tmp_path):
     NEBARI_CONFIG_FN = "nebari-config.yaml"
 
-    config_filename = tmp_path / NEBARI_CONFIG_FN
-    write_configuration(config_filename, nebari_config)
-    render_template(tmp_path, nebari_config, nebari_stages)
-    return tmp_path, config_filename
+    # Save original cwd and change to tmp_path so files that should be generated
+    # in the repo root are put in the right place
+    original_cwd = os.getcwd()
+    os.chdir(tmp_path)
+
+    try:
+        config_filename = tmp_path / NEBARI_CONFIG_FN
+        write_configuration(config_filename, nebari_config)
+        render_template(tmp_path, nebari_config, nebari_stages)
+        return tmp_path, config_filename
+    finally:
+        # Always restore original cwd
+        os.chdir(original_cwd)
 
 
 @pytest.fixture

--- a/tests/tests_unit/conftest.py
+++ b/tests/tests_unit/conftest.py
@@ -185,7 +185,7 @@ def nebari_render(nebari_config, nebari_stages, tmp_path):
 
     # Save original cwd and change to tmp_path so files that should be generated
     # in the repo root are put in the right place
-    original_cwd = os.getcwd()
+    original_cwd = Path.cwd()
     os.chdir(tmp_path)
 
     try:

--- a/tests/tests_unit/test_bootstrap.py
+++ b/tests/tests_unit/test_bootstrap.py
@@ -1,0 +1,70 @@
+import os
+import pathlib
+import tempfile
+from unittest.mock import patch
+
+import pytest
+
+from _nebari.stages.bootstrap import gen_gitignore
+
+
+class TestGenGitignore:
+    """Test the gen_gitignore function."""
+
+    def test_gen_gitignore_creates_file_when_not_exists(self, tmp_path):
+        """Test that gen_gitignore returns gitignore content when file doesn't exist."""
+        with patch("pathlib.Path.exists", return_value=False):
+            result = gen_gitignore()
+
+        assert pathlib.Path(".gitignore") in result
+        assert "terraform.tfstate" in result[pathlib.Path(".gitignore")]
+        assert "__pycache__" in result[pathlib.Path(".gitignore")]
+
+    def test_gen_gitignore_skips_when_exists(self, tmp_path):
+        """Test that gen_gitignore returns empty dict when .gitignore already exists."""
+        with patch("pathlib.Path.exists", return_value=True):
+            result = gen_gitignore()
+
+        assert result == {}
+
+    def test_gen_gitignore_content_format(self, tmp_path):
+        """Test that gen_gitignore returns properly formatted content."""
+        with patch("pathlib.Path.exists", return_value=False):
+            result = gen_gitignore()
+
+        content = result[pathlib.Path(".gitignore")]
+        expected_patterns = [
+            "# ignore terraform state",
+            ".terraform",
+            "terraform.tfstate",
+            "terraform.tfstate.backup",
+            ".terraform.tfstate.lock.info",
+            "# python",
+            "__pycache__"
+        ]
+
+        for pattern in expected_patterns:
+            assert pattern in content
+
+    def test_gen_gitignore_file_system_integration(self, tmp_path):
+        """Test gen_gitignore behavior with actual file system."""
+        # Change to tmp directory
+        original_cwd = pathlib.Path.cwd()
+        os.chdir(tmp_path)
+
+        try:
+            # Test when .gitignore doesn't exist
+            result = gen_gitignore()
+            assert pathlib.Path(".gitignore") in result
+
+            # Create .gitignore file
+            gitignore_path = tmp_path / ".gitignore"
+            gitignore_path.write_text("existing content")
+
+            # Test when .gitignore exists
+            result = gen_gitignore()
+            assert result == {}
+
+        finally:
+            # Restore original working directory
+            os.chdir(original_cwd)

--- a/tests/tests_unit/test_bootstrap.py
+++ b/tests/tests_unit/test_bootstrap.py
@@ -1,9 +1,6 @@
 import os
 import pathlib
-import tempfile
 from unittest.mock import patch
-
-import pytest
 
 from _nebari.stages.bootstrap import gen_gitignore
 
@@ -40,7 +37,7 @@ class TestGenGitignore:
             "terraform.tfstate.backup",
             ".terraform.tfstate.lock.info",
             "# python",
-            "__pycache__"
+            "__pycache__",
         ]
 
         for pattern in expected_patterns:


### PR DESCRIPTION
Fixes #3104

## What does this implement/fix?

When running `nebari render` my existing .gitignore was clobbered. If there is already a .gitignore, this step should be a no-op.

_Put a `x` in the boxes that apply_

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds a feature)
- [ ] Breaking change (fix or feature that would cause existing features not to work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Other (please describe):


## Testing

- [X] Did you test the pull request locally?
- [X] Did you add new tests?

## How to test this PR?

Use `nebari render` without a previously existing .gitignore, one should be created.
Use `nebari render` with a previously existing .gitignore, it should not be changed.