### PR TITLE
fix: keycloak export script requires config, not PosixPath

### DIFF
--- a/scripts/keycloak-export.py
+++ b/scripts/keycloak-export.py
@@ -5,6 +5,7 @@ import sys
 from pathlib import Path
 
 from _nebari.keycloak import get_keycloak_admin_from_config
+from nebari.plugins import nebari_plugin_manager
 
 logging.basicConfig(level=logging.INFO)
 
@@ -24,7 +25,8 @@ def handle_keycloak_export(args):
             f"passed in configuration filename={config_filename} must exist"
         )
 
-    keycloak_admin = get_keycloak_admin_from_config(config_filename)
+    config = nebari_plugin_manager.read_config(config_filename)
+    keycloak_admin = get_keycloak_admin_from_config(config)
 
     realm = {"id": "nebari", "realm": "nebari"}
 


### PR DESCRIPTION
Running the keycloak export script as written results in: 

```
  File "/home/austin/devel/nebari/src/_nebari/keycloak.py", line 152, in get_keycloak_admin_from_config
    "KEYCLOAK_SERVER_URL", f"https://{config.domain}/auth/"
                                      ^^^^^^^^^^^^^
AttributeError: 'PosixPath' object has no attribute 'domain'
```
## What does this implement/fix?

_Put a `x` in the boxes that apply_

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds a feature)
- [ ] Breaking change (fix or feature that would cause existing features not to work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Other (please describe):

## Documentation

- [ ] For new features or enhancements, a corresponding PR has been opened in the [documentation repository](https://github.com/nebari-dev/nebari-docs) (if applicable)
  - Link to docs PR:

## Testing

- [] Did you test the pull request locally?
- [ ] Did you add new tests?

## How to test this PR?

<!--
If relevant, please outline the steps required to test your contribution
and the expected outcomes from the proposed changes. Providing clear
testing instructions will help reviewers evaluate your contribution.
-->

## Any other comments?

<!--
Please be aware that we are a loose team of volunteers, so patience is necessary;
assistance handling other issues is very welcome.
We value all user contributions. If we are slow to review, either the pull request needs some benchmarking, tinkering,
convincing, etc., or the reviewers are likely busy. In either case,
we ask for your understanding during the
review process.
Thanks for contributing to Nebari 🙏🏼!
-->
