### PR TITLE
Pin checkout version due node24 support bug

### DIFF
--- a/.github/workflows/test_local_integration.yaml
+++ b/.github/workflows/test_local_integration.yaml
@@ -52,7 +52,8 @@ jobs:
         shell: bash -l {0}
     steps:
       - name: "Checkout Infrastructure"
-        uses: actions/checkout@main
+      # Pin checkout version due to issue with node24 support on self-hosted runners
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -157,7 +158,8 @@ jobs:
 
       ### CONDA-STORE TESTS
       - name: "Checkout conda-store"
-        uses: actions/checkout@main
+        # Pin checkout version due to issue with node24 support on self-hosted runners
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           repository: conda-incubator/conda-store


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://nebari.dev/community
-->

## Reference Issues or PRs

Yesterday, the checkout action got a significant update, `v5`, which included support for the new `node24` version, though right now our current self-hosted runners don't support this version of node yet, leading to the following error on CI:
```shell
Current runner version: '2.326.0'
Runner name: 'cirun-nebari-dev--nebari-563c8f97a1'
Runner group name: 'Default'
...
Prepare workflow directory
Prepare all required actions
Getting action download info
Download action repository 'actions/checkout@main' (SHA:08c6903cd8c0fde910a37f88322edcfb5dd907a8)
Download action repository 'conda-incubator/setup-miniconda@v3' (SHA:505e6394dae86d6a5c7fbb6e3fb8938e3e863830)
Download action repository 'jupyterhub/action-k8s-await-workloads@v3' (SHA:a9c715420536831dd16df5ef775b3239d97db008)
Download action repository 'actions/setup-node@v4' (SHA:49933ea5288caeca8642d1e84afbd3f7d6820020)
Download action repository 'actions/upload-artifact@v4.3.1' (SHA:5d5d22a31266ced268874388b861e4b58bb5c2f3)
Error: System.ArgumentOutOfRangeException: Specified argument was out of the range of valid values. (Parameter ''using: node24' is not supported, use 'docker', 'node12', 'node16' or 'node20' instead.')
   at GitHub.Runner.Worker.ActionManifestManager.ConvertRuns(IExecutionContext executionContext, TemplateContext templateContext, TemplateToken inputsToken, String fileRelativePath, MappingToken outputs)
   at GitHub.Runner.Worker.ActionManifestManager.Load(IExecutionContext executionContext, String manifestFile)
Error: Failed to load actions/checkout/main/action.yml
```
To avoid this error for now, until an update exists on GH/self-hosted configurations ([see this comment for an update on that](https://www.github.com/orgs/community/discussions/160454#discussioncomment-13420519)), I am pinning the version down to `v4` for this action since this is a blocker for other tests/PRs and our release.

<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create a link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

## What does this implement/fix?

_Put a `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds a feature)
- [ ] Breaking change (fix or feature that would cause existing features not to work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Other (please describe):

## Documentation

- [ ] For new features or enhancements, a corresponding PR has been opened in the [documentation repository](https://github.com/nebari-dev/nebari-docs) (if applicable)
  - Link to docs PR:

## Testing

- [ ] Did you test the pull request locally?
- [ ] Did you add new tests?

## How to test this PR?

<!--
If relevant, please outline the steps required to test your contribution
and the expected outcomes from the proposed changes. Providing clear
testing instructions will help reviewers evaluate your contribution.
-->

## Any other comments?

Upstream issue on [checkout main repo](https://www.github.com/actions/checkout/issues/2240)
<!--
Please be aware that we are a loose team of volunteers, so patience is necessary;
assistance handling other issues is very welcome.
We value all user contributions. If we are slow to review, either the pull request needs some benchmarking, tinkering,
convincing, etc., or the reviewers are likely busy. In either case,
we ask for your understanding during the
review process.
Thanks for contributing to Nebari 🙏🏼!
-->
