### PR TITLE
Add configurable log level option to CLI

### DIFF
--- a/src/_nebari/cli.py
+++ b/src/_nebari/cli.py
@@ -1,3 +1,4 @@
+import logging
 import typing
 
 import typer
@@ -27,6 +28,31 @@ def exclude_stages(ctx: typer.Context, stages: typing.List[str]):
 def exclude_default_stages(ctx: typer.Context, exclude_default_stages: bool):
     nebari_plugin_manager.exclude_default_stages = exclude_default_stages
     return exclude_default_stages
+
+
+def configure_logging(log_level: str):
+    """Configure logging level based on log level string."""
+    level_map = {
+        "debug": logging.DEBUG,
+        "info": logging.INFO,
+        "warning": logging.WARNING,
+        "error": logging.ERROR,
+        "critical": logging.CRITICAL,
+    }
+
+    level = level_map.get(log_level.lower(), logging.INFO)
+
+    if level == logging.DEBUG:
+        logging.basicConfig(
+            level=level,
+            format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+            force=True,
+        )
+    else:
+        logging.basicConfig(
+            level=level, format="%(levelname)s - %(message)s", force=True
+        )
+    return log_level
 
 
 def import_plugin(plugins: typing.List[str]):
@@ -60,6 +86,13 @@ def create_cli():
             "--version",
             help="Nebari version number",
             callback=version_callback,
+        ),
+        log_level: str = typer.Option(
+            "info",
+            "-l",
+            "--log-level",
+            help="Set logging level (debug, info, warning, error, critical)",
+            callback=configure_logging,
         ),
         plugins: typing.List[str] = typer.Option(
             [],

--- a/src/_nebari/cli.py
+++ b/src/_nebari/cli.py
@@ -31,8 +31,11 @@ def exclude_default_stages(ctx: typer.Context, exclude_default_stages: bool):
     return exclude_default_stages
 
 
-def configure_logging(log_level: str):
+def configure_logging(log_level: None | str) -> None:
     """Configure logging level based on log level string."""
+    if not log_level:
+        return
+
     level_map = {
         "trace": logging.DEBUG,
         "debug": logging.DEBUG,
@@ -68,7 +71,7 @@ def configure_logging(log_level: str):
         logging.basicConfig(
             level=level, format="%(levelname)s - %(message)s", force=True
         )
-    return log_level
+    return
 
 
 def import_plugin(plugins: typing.List[str]):
@@ -104,7 +107,7 @@ def create_cli():
             callback=version_callback,
         ),
         log_level: str = typer.Option(
-            "warning",
+            None,
             "-l",
             "--log-level",
             help="Set logging level (trace, debug, info, warning, error, critical)",

--- a/tests/tests_unit/test_cli.py
+++ b/tests/tests_unit/test_cli.py
@@ -1,7 +1,10 @@
+import logging
+import os
 import subprocess
 
 import pytest
 
+from _nebari.cli import configure_logging
 from _nebari.subcommands.init import InitInputs
 from nebari.plugins import nebari_plugin_manager
 
@@ -65,3 +68,118 @@ def test_nebari_init(tmp_path, namespace, auth_provider, ci_provider, ssl_cert_e
 )
 def test_nebari_commands_no_args(command):
     subprocess.run(command, check=True, capture_output=True, text=True).stdout.strip()
+
+
+@pytest.mark.parametrize(
+    "log_level,expected_python_level,expected_tf_level",
+    [
+        ("trace", logging.DEBUG, "TRACE"),
+        ("debug", logging.DEBUG, "DEBUG"),
+        ("info", logging.INFO, "INFO"),
+        ("warning", logging.WARNING, "WARN"),
+        ("error", logging.ERROR, "ERROR"),
+        ("critical", logging.CRITICAL, "ERROR"),
+    ],
+)
+def test_configure_logging_levels(
+    log_level, expected_python_level, expected_tf_level, monkeypatch
+):
+    """Test that configure_logging sets correct Python and Terraform log levels."""
+    # Remove TF_LOG from environment if it exists
+    monkeypatch.delenv("TF_LOG", raising=False)
+
+    # Configure logging with the specified level
+    configure_logging(log_level)
+
+    # Check that Python logging level is set correctly
+    root_logger = logging.getLogger()
+    assert root_logger.level == expected_python_level
+
+    # Check that TF_LOG environment variable is set correctly
+    assert os.environ.get("TF_LOG") == expected_tf_level
+
+
+def test_configure_logging_with_none(monkeypatch):
+    """Test that configure_logging returns early when log_level is None."""
+    # Remove TF_LOG from environment if it exists
+    monkeypatch.delenv("TF_LOG", raising=False)
+
+    # Get initial logging level
+    initial_level = logging.getLogger().level
+
+    # Call with None
+    configure_logging(None)
+
+    # Verify logging level hasn't changed
+    assert logging.getLogger().level == initial_level
+
+    # Verify TF_LOG wasn't set
+    assert "TF_LOG" not in os.environ
+
+
+def test_configure_logging_preserves_existing_tf_log(monkeypatch):
+    """Test that configure_logging doesn't override existing TF_LOG variable."""
+    # Set TF_LOG to a specific value
+    monkeypatch.setenv("TF_LOG", "TRACE")
+
+    # Configure logging with a different level
+    configure_logging("error")
+
+    # Verify TF_LOG wasn't changed
+    assert os.environ["TF_LOG"] == "TRACE"
+
+
+def test_configure_logging_debug_format():
+    """Test that DEBUG level uses detailed format with timestamp."""
+    configure_logging("debug")
+
+    # Get the root logger
+    root_logger = logging.getLogger()
+
+    # Check that level is DEBUG
+    assert root_logger.level == logging.DEBUG
+
+    # Check that at least one handler exists (basicConfig creates one)
+    assert len(root_logger.handlers) > 0
+
+
+def test_configure_logging_non_debug_format():
+    """Test that non-DEBUG levels use simpler format without timestamp."""
+    configure_logging("info")
+
+    # Get the root logger
+    root_logger = logging.getLogger()
+
+    # Check that level is INFO
+    assert root_logger.level == logging.INFO
+
+    # Check that at least one handler exists
+    assert len(root_logger.handlers) > 0
+
+
+@pytest.mark.parametrize(
+    "log_level",
+    ["trace", "debug", "info", "warning", "error"],
+)
+def test_cli_with_log_level(log_level, monkeypatch):
+    """Test that the CLI accepts and processes the --log-level option."""
+    # Remove TF_LOG from environment if it exists
+    monkeypatch.delenv("TF_LOG", raising=False)
+
+    command = ["nebari", "--log-level", log_level, "info"]
+    result = subprocess.run(command, check=True, capture_output=True, text=True)
+
+    # Command should succeed
+    assert result.returncode == 0
+
+
+def test_cli_with_short_log_level_option(monkeypatch):
+    """Test that the CLI accepts the -l short option for log level."""
+    # Remove TF_LOG from environment if it exists
+    monkeypatch.delenv("TF_LOG", raising=False)
+
+    command = ["nebari", "-l", "debug", "info"]
+    result = subprocess.run(command, check=True, capture_output=True, text=True)
+
+    # Command should succeed
+    assert result.returncode == 0


### PR DESCRIPTION
There's currently no easy way to adjust the log level output from nebari commands.  This PR resolves that.

## Specifics
- Add `--log-level/-l` CLI option accepting debug, info, warning, error, critical levels
- Maintain detailed formatting for debug level with timestamps and module names
- Default to info level for optimal user experience

## Test plan
- [x] Verified CLI option accepts all log levels correctly
- [x] Confirmed debug level shows detailed format
- [x] Confirmed other levels use simple format
- [x] Passes pre-commit hooks and formatting