### PR TITLE
Update references from qhub-hpc to nebari-slurm and organizational updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,8 +137,8 @@ For detailed step-by-step instructions on how to deploy Nebari, check the [Nebar
 
 ## Nebari HPC
 
-An HPC version of Nebari is currently not available. There is one under development for Nebari's precursor QHub.
-Curious? Check out the [QHub HPC](https://github.com/Quansight/qhub-hpc) repository.
+An HPC version of Nebari is available for SLURM-based high-performance computing environments.
+Check out the [Nebari SLURM](https://github.com/nebari-dev/nebari-slurm) repository.
 
 ## Contributing to Nebari 👩🏻‍💻
 

--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ Getting help:
 
 ## Code of Conduct 📖
 
-To guarantee a welcoming and friendly community, we require all community members to follow our [Code of Conduct](https://github.com/Quansight/.github/blob/master/CODE_OF_CONDUCT.md).
+To guarantee a welcoming and friendly community, we require all community members to follow our [Code of Conduct](https://github.com/nebari-dev/.github/blob/main/CODE_OF_CONDUCT.md).
 
 ## Ongoing Support
 

--- a/tests/tests_unit/cli_validate/min.happy.certificate.yaml
+++ b/tests/tests_unit/cli_validate/min.happy.certificate.yaml
@@ -1,6 +1,6 @@
 project_name: test
 certificate:
   type: lets-encrypt
-  acme_email: admin@quansight.com
+  acme_email: fake-admin@openteams.com
   acme_server: https://acme-v02.api.letsencrypt.org/directory
   acme_challenge_type: dns


### PR DESCRIPTION
## Summary
- Updated README to reference the new nebari-slurm repository instead of the deprecated qhub-hpc repository
- Updated Code of Conduct link to point to nebari-dev organization
- Updated test email from quansight.com to openteams.com domain