### PR TITLE
Fix verbose OpenTofu error tracebacks

### DIFF
--- a/src/_nebari/provider/opentofu.py
+++ b/src/_nebari/provider/opentofu.py
@@ -112,12 +112,16 @@ def download_opentofu_binary(version=constants.OPENTOFU_VERSION):
     return filename_path
 
 
-def run_tofu_subprocess(processargs, **kwargs):
+def run_tofu_subprocess(processargs, exit_on_error=True, **kwargs):
     tofu_path = download_opentofu_binary()
     logger.info(f" tofu at {tofu_path}")
     exit_code, output = run_subprocess_cmd([tofu_path] + processargs, **kwargs)
     if exit_code != 0:
-        raise OpenTofuException("OpenTofu returned an error")
+        if exit_on_error:
+            logger.error("Error: OpenTofu command failed")
+            sys.exit(1)
+        else:
+            raise OpenTofuException("OpenTofu returned an error")
     return output
 
 
@@ -174,6 +178,7 @@ def tfimport(addr, id, directory=None, var_files=None, exist_ok=False):
         try:
             run_tofu_subprocess(
                 command,
+                exit_on_error=False,
                 cwd=directory,
                 prefix="tofu",
                 strip_errors=True,
@@ -196,6 +201,7 @@ def show(directory=None, tofu_init: bool = True) -> dict:
             output = json.loads(
                 run_tofu_subprocess(
                     command,
+                    exit_on_error=False,
                     cwd=directory,
                     prefix="tofu",
                     strip_errors=True,


### PR DESCRIPTION
## Summary

Fixes #1946 - Removes unnecessarily long Python tracebacks when OpenTofu commands fail, providing users with clean, actionable error messages instead.

## Changes

Modified `run_tofu_subprocess()` in `src/_nebari/provider/opentofu.py` to:
- Exit cleanly with `sys.exit(1)` for main operations (init, apply, destroy, refresh) instead of raising an exception
- Add an `exit_on_error` parameter (default `True`) to control this behavior  
- Preserve `OpenTofuException` raising for optional operations that need error handling (import with `exist_ok`, show)

## Impact

When OpenTofu commands fail (e.g., Helm chart errors, resource conflicts), users will now see only the relevant OpenTofu error output and a simple error message, without the long Python traceback chain that obscured the actual problem.

## Test plan

- [x] Manual testing with deployment failures
- [x] Verified that optional operations (import with `exist_ok=True`, show with error handling) still work correctly
- [ ] CI tests pass