### PR TITLE
Fix Nebari Destroy on GCP (deletion_protection=False)

### DIFF
--- a/src/_nebari/stages/infrastructure/template/gcp/modules/kubernetes/main.tf
+++ b/src/_nebari/stages/infrastructure/template/gcp/modules/kubernetes/main.tf
@@ -2,9 +2,9 @@ data "google_client_config" "main" {
 }
 
 resource "google_container_cluster" "main" {
-  name               = var.name
-  location           = var.location
-  min_master_version = var.kubernetes_version
+  name                = var.name
+  location            = var.location
+  min_master_version  = var.kubernetes_version
   deletion_protection = false
 
   node_locations = var.availability_zones


### PR DESCRIPTION
Add deletion_protection = false flag to google_container_cluster resource to allow cluster destruction without requiring a two-step process. This resolves the error that occurs when running 'nebari destroy' on GCP clusters with Google Terraform provider version 5.0.0+.

Fixes #3098

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://nebari.dev/community
-->

## Reference Issues or PRs

<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create a link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

## What does this implement/fix?

_Put a `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds a feature)
- [ ] Breaking change (fix or feature that would cause existing features not to work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Other (please describe):

## Documentation

- [ ] For new features or enhancements, a corresponding PR has been opened in the [documentation repository](https://github.com/nebari-dev/nebari-docs) (if applicable)
  - Link to docs PR:

## Testing

- [ ] Did you test the pull request locally?
- [ ] Did you add new tests?

## How to test this PR?

<!--
If relevant, please outline the steps required to test your contribution
and the expected outcomes from the proposed changes. Providing clear
testing instructions will help reviewers evaluate your contribution.
-->

## Any other comments?

<!--
Please be aware that we are a loose team of volunteers, so patience is necessary;
assistance handling other issues is very welcome.
We value all user contributions. If we are slow to review, either the pull request needs some benchmarking, tinkering,
convincing, etc., or the reviewers are likely busy. In either case,
we ask for your understanding during the
review process.
Thanks for contributing to Nebari 🙏🏼!
-->
