### PR TITLE
Use updated google auth method

### DIFF
--- a/src/_nebari/provider/cloud/google_cloud.py
+++ b/src/_nebari/provider/cloud/google_cloud.py
@@ -4,8 +4,9 @@ import os
 from typing import List, Set
 
 import google.api_core.exceptions
-from google.auth import load_credentials_from_dict, load_credentials_from_file
+from google.auth import load_credentials_from_dict
 from google.cloud import compute_v1, container_v1, iam_admin_v1, storage
+from google.oauth2 import service_account
 
 from _nebari.constants import GCP_ENV_DOCS
 from _nebari.provider.cloud.commons import filter_by_highest_supported_k8s_version
@@ -32,7 +33,9 @@ def load_credentials():
     # to determine if the credentials are stored as a file or not before
     # reading them
     if credentials.endswith(".json"):
-        loaded_credentials, _ = load_credentials_from_file(credentials, scopes=scopes)
+        loaded_credentials = service_account.Credentials.from_service_account_file(
+            credentials, scopes=scopes
+        )
     else:
         loaded_credentials, _ = load_credentials_from_dict(
             json.loads(credentials), scopes=scopes


### PR DESCRIPTION
## What does this implement/fix?

_Put a `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds a feature)
- [ ] Breaking change (fix or feature that would cause existing features not to work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Other (please describe):

## Testing

- [x] Did you test the pull request locally?
- [ ] Did you add new tests?

## Any other comments?

<!--
Please be aware that we are a loose team of volunteers, so patience is necessary;
assistance handling other issues is very welcome.
We value all user contributions. If we are slow to review, either the pull request needs some benchmarking, tinkering,
convincing, etc., or the reviewers are likely busy. In either case,
we ask for your understanding during the
review process.
Thanks for contributing to Nebari 🙏🏼!
-->
The Google auth library was throwing this warning:

```
warnings.warn(_GENERIC_LOAD_METHOD_WARNING.format(method_name), DeprecationWarning)
DeprecationWarning: The load_credentials_from_file method is deprecated because of a potential security risk.

This method does not validate the credential configuration. The security
risk occurs when a credential configuration is accepted from a source that
is not under your control and used without validation on your side.

If you know that you will be loading credential configurations of a
specific type, it is recommended to use a credential-type-specific
load method.
This will ensure that an unexpected credential type with potential for
malicious intent is not loaded unintentionally. You might still have to do
validation for certain credential types. Please follow the recommendations
for that method. For example, if you want to load only service accounts,
you can create the service account credentials explicitly:


from google.oauth2 import service_account
creds = service_account.Credentials.from_service_account_file(filename)


If you are loading your credential configuration from an untrusted source and have
not mitigated the risks (e.g. by validating the configuration yourself), make
these changes as soon as possible to prevent security risks to your environment.

Regardless of the method used, it is always your responsibility to validate
configurations received from external sources.

Refer to https://cloud.google.com/docs/authentication/external/externally-sourced-credentials
for more details
```

This was causing tests to fail with the following:

```
FAILED tests_deployment/test_conda_store_roles_loaded.py::test_conda_store_roles_loaded_from_keycloak[admin!namespace=analyst,developer!namespace=nebari-git-changed_scopes0] - DeprecationWarning: The load_credentials_from_file method is deprecated because of a potential security risk.
```

This PR updates to the new authentication method