### PR TITLE
fix: EBS CSI driver crashes on AL2023 — missing IRSA role on addon

### DIFF
--- a/src/_nebari/stages/infrastructure/template/aws/modules/kubernetes/main.tf
+++ b/src/_nebari/stages/infrastructure/template/aws/modules/kubernetes/main.tf
@@ -151,6 +151,7 @@ resource "aws_eks_addon" "aws-ebs-csi-driver" {
   # required for Kubernetes v1.23+ on AWS
   addon_name                  = "aws-ebs-csi-driver"
   cluster_name                = aws_eks_cluster.main.name
+  service_account_role_arn    = aws_iam_role.ebs_csi_driver.arn
   resolve_conflicts_on_create = "OVERWRITE"
   resolve_conflicts_on_update = "OVERWRITE"
 


### PR DESCRIPTION
## Summary

The EBS CSI addon was created without `service_account_role_arn` in #3166, leaving the controller without AWS credentials (no IRSA, no IMDS fallback). This caused the controller to crashloop with `no EC2 IMDS role found`, preventing all PVC provisioning. One-line fix: wire the existing IRSA role to the addon.

There is no viable manual workaround — attaching the role via `aws eks update-addon` creates drift that causes nebari to fail with `Cross-account pass role is not allowed` on the next deploy.

After applying this fix (and correcting various drift from manual debugging), the staging cluster was fully recovered. Keycloak data was lost due to PVC recreation during recovery but that's a non-issue on staging.

cc @viniciusdc

<details><summary>Debug logs</summary>

### EBS CSI controller had no AWS creds
```
kubectl logs -n kube-system ebs-csi-controller-<pod> --all-containers --tail=50
```
```
Failed health check (verify network connection and IAM credentials):
dry-run EC2 API call failed:
operation error EC2: DescribeAvailabilityZones,
get identity: get credentials:
failed to refresh cached credentials,
no EC2 IMDS role found
```

### CSI controller crashlooping
```
kubectl get pods -n kube-system | grep ebs
```
```
ebs-csi-controller-xxxxx   1/6   CrashLoopBackOff
```

### PVCs stuck waiting for provisioner
```
kubectl describe pvc <pvc-name>
```
```
Waiting for a volume to be created either by the external provisioner 'ebs.csi.aws.com'
```

### Addon missing IRSA
```
aws eks describe-addon --cluster-name dandi-hub-staging --addon-name aws-ebs-csi-driver
```
```json
"status": "DEGRADED"
// no serviceAccountRoleArn present
```

### Manual role attach causes drift on next deploy
```
aws eks update-addon --service-account-role-arn arn:aws:iam::<acct>:role/...
```
Controller recovers, but next `nebari deploy` fails:
```
Error: updating EKS Add-On: AccessDeniedException: Cross-account pass role is not allowed.
```

</details>

## Test plan
- [x] Tested against live AWS EKS deployment upgrading from AL2 to AL2023
- [x] Confirmed removing and re-adding IRSA reproduces and fixes the issue deterministically

🤖 Generated with [Claude Code](https://claude.com/claude-code)