### PR TITLE
fix: stop printing Keycloak root password in cleartext during deploy

### DIFF
--- a/src/_nebari/deploy.py
+++ b/src/_nebari/deploy.py
@@ -70,7 +70,9 @@ def deploy_configuration(
         username = "root"
         password = config.security.keycloak.initial_root_password
         if password:
-            print(f"Kubecloak master realm username={username} password={password}")
+            print(
+                f"Keycloak master realm username={username} password=<set via config/env>"
+            )
 
         print(
             "Additional administration docs can be found at https://www.nebari.dev/docs/how-tos/configuring-keycloak"

--- a/src/_nebari/deploy.py
+++ b/src/_nebari/deploy.py
@@ -1,5 +1,6 @@
 import contextlib
 import logging
+import os
 import pathlib
 import textwrap
 from typing import Any, Dict, List
@@ -70,9 +71,15 @@ def deploy_configuration(
         username = "root"
         password = config.security.keycloak.initial_root_password
         if password:
-            print(
-                f"Keycloak master realm username={username} password=<set via config/env>"
+            password_from_env = os.environ.get(
+                "NEBARI_SECRET__security__keycloak__initial_root_password"
             )
+            if password_from_env:
+                print(
+                    f"Keycloak master realm username={username} password=<set via env>"
+                )
+            else:
+                print(f"Keycloak master realm username={username} password={password}")
 
         print(
             "Additional administration docs can be found at https://www.nebari.dev/docs/how-tos/configuring-keycloak"


### PR DESCRIPTION
## Summary

Closes https://github.com/orgs/nebari-dev/discussions/3216

The deploy output was printing the Keycloak root password in cleartext, which is a security concern — especially when the password is injected via `NEBARI_SECRET__` environment variables specifically to avoid having it in config files.

## Changes

### `src/_nebari/deploy.py`
- When the password is set via `NEBARI_SECRET__security__keycloak__initial_root_password` env var, mask it in the deploy log with `<set via env>`
- When the password comes from the config file or is auto-generated (e.g. first deploy), still print it so the user can retrieve it
- Fix pre-existing "Kubecloak" typo → "Keycloak"

## Before / After

```bash
# Before (always prints cleartext)
Keycloak master realm username=root password=MY_ACTUAL_SECRET_PASSWORD

# After (password from env var)
Keycloak master realm username=root password=<set via env>

# After (password from config or auto-generated — unchanged)
Keycloak master realm username=root password=MY_ACTUAL_SECRET_PASSWORD
```
